### PR TITLE
Add Error implementation for LoadError

### DIFF
--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -186,6 +186,26 @@ impl From<std::io::Error> for LoadError {
     }
 }
 
+impl std::error::Error for LoadError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        Some(match &self {
+            LoadError::IO(e) => e,
+            LoadError::Scan(e) => e,
+            LoadError::Decode(_) => return None,
+        })
+    }
+}
+
+impl std::fmt::Display for LoadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LoadError::IO(e) => e.fmt(f),
+            LoadError::Scan(e) => e.fmt(f),
+            LoadError::Decode(e) => e.fmt(f),
+        }
+    }
+}
+
 impl YamlLoader {
     fn insert_new_node(&mut self, node: (Yaml, usize)) {
         // valid anchor id starts from 1


### PR DESCRIPTION
This brings `LoadError` in line with the other error types in the crate and allows it to be used with error handling libraries like `anyhow`.

Details on whether more Error methods should be implemented or the format of the Display implementation can be changed but I wanted to get an implementation out there.