### PR TITLE
Add fuzzing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "bench",
     "bench/tools/gen_large_yaml",
     "bench/tools/bench_compare",
+    "fuzz",
 ]
 resolver = "2"
 

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "saphyr-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+saphyr.workspace = true
+
+[[bin]]
+name = "parse"
+path = "fuzz_targets/parse.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/parse.rs
+++ b/fuzz/fuzz_targets/parse.rs
@@ -1,0 +1,9 @@
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(s) = std::str::from_utf8(data) {
+        let _ = saphyr::Yaml::load_from_str(&s);
+    }
+});

--- a/fuzz/fuzz_targets/parse.rs
+++ b/fuzz/fuzz_targets/parse.rs
@@ -4,6 +4,6 @@ use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
     if let Ok(s) = std::str::from_utf8(data) {
-        let _ = saphyr::Yaml::load_from_str(&s);
+        let _ = saphyr::Yaml::load_from_str(s);
     }
 });


### PR DESCRIPTION
Running the fuzzer requires `cargo fuzz` installed. It's [incompatible](https://github.com/rust-fuzz/cargo-fuzz/issues/384) with lto, so you'll have to comment out the `lto = true` line in `Cargo.toml`. Then running `cargo fuzz run parse` should run the fuzzer.