### PR TITLE
Parse `.Nan` as float

### DIFF
--- a/saphyr/CHANGELOG.md
+++ b/saphyr/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Upcoming
 
+**Breaking Changes**:
+
+- Parse `.NaN` as float instead of `NaN`.
+
 ## v0.0.3
 
 Skipping version `v0.0.2` to align this crate's version with that of
@@ -28,7 +32,7 @@ Skipping version `v0.0.2` to align this crate's version with that of
     `Yaml::Hash` for `&'a str`
 
 - Use cargo features
-  
+
   This allows for more fine-grained control over MSRV and to completely remove
   debug code from the library when it is consumed.
 

--- a/saphyr/src/loader.rs
+++ b/saphyr/src/loader.rs
@@ -304,7 +304,7 @@ pub(crate) fn parse_f64(v: &str) -> Option<f64> {
     match v {
         ".inf" | ".Inf" | ".INF" | "+.inf" | "+.Inf" | "+.INF" => Some(f64::INFINITY),
         "-.inf" | "-.Inf" | "-.INF" => Some(f64::NEG_INFINITY),
-        ".nan" | "NaN" | ".NAN" => Some(f64::NAN),
+        ".nan" | ".NaN" | ".NAN" => Some(f64::NAN),
         _ => v.parse::<f64>().ok(),
     }
 }


### PR DESCRIPTION
but no longer consider `NaN` a float.

Fixes #30.