### PR TITLE
Implement From YamlOwned for Yaml

### DIFF
--- a/parser/tests/yaml-test-suite.rs
+++ b/parser/tests/yaml-test-suite.rs
@@ -1,4 +1,7 @@
-use std::fs::{self, DirEntry};
+use std::{
+    borrow::Cow,
+    fs::{self, DirEntry},
+};
 
 use libtest_mimic::{run_tests, Arguments, Outcome, Test};
 
@@ -213,12 +216,12 @@ impl<'input> SpannedEventReceiver<'input> for EventReporter<'input> {
             Event::DocumentEnd => "-DOC".into(),
 
             Event::SequenceStart(idx, tag) => {
-                format!("+SEQ{}{}", format_index(idx), format_tag(tag.as_ref()))
+                format!("+SEQ{}{}", format_index(idx), format_tag(&tag))
             }
             Event::SequenceEnd => "-SEQ".into(),
 
             Event::MappingStart(idx, tag) => {
-                format!("+MAP{}{}", format_index(idx), format_tag(tag.as_ref()))
+                format!("+MAP{}{}", format_index(idx), format_tag(&tag))
             }
             Event::MappingEnd => "-MAP".into(),
 
@@ -233,7 +236,7 @@ impl<'input> SpannedEventReceiver<'input> for EventReporter<'input> {
                 format!(
                     "=VAL{}{} {kind}{}",
                     format_index(idx),
-                    format_tag(tag.as_ref()),
+                    format_tag(tag),
                     escape_text(text)
                 )
             }
@@ -266,8 +269,8 @@ fn escape_text(text: &str) -> String {
     text
 }
 
-fn format_tag(tag: Option<&Tag>) -> String {
-    if let Some(tag) = tag {
+fn format_tag(tag: &Option<Cow<'_, Tag>>) -> String {
+    if let Some(tag) = tag.as_ref().map(Cow::as_ref) {
         format!(" <{}{}>", tag.handle, tag.suffix)
     } else {
         String::new()

--- a/saphyr/src/annotated/marked_yaml.rs
+++ b/saphyr/src/annotated/marked_yaml.rs
@@ -75,7 +75,7 @@ impl<'input> MarkedYaml<'input> {
         style: ScalarStyle,
         tag: Option<&Tag>,
     ) -> Self {
-        Scalar::parse_from_cow_and_metadata(v, style, tag.map(Cow::Borrowed).as_ref()).map_or_else(
+        Scalar::parse_from_cow_and_metadata(v, style, tag).map_or_else(
             || Self {
                 data: YamlData::BadValue,
                 span: Span::default(),

--- a/saphyr/src/annotated/marked_yaml.rs
+++ b/saphyr/src/annotated/marked_yaml.rs
@@ -73,7 +73,7 @@ impl<'input> MarkedYaml<'input> {
     pub fn value_from_cow_and_metadata(
         v: Cow<'input, str>,
         style: ScalarStyle,
-        tag: Option<&Tag>,
+        tag: Option<&Cow<'input, Tag>>,
     ) -> Self {
         Scalar::parse_from_cow_and_metadata(v, style, tag).map_or_else(
             || Self {

--- a/saphyr/src/annotated/marked_yaml.rs
+++ b/saphyr/src/annotated/marked_yaml.rs
@@ -75,7 +75,7 @@ impl<'input> MarkedYaml<'input> {
         style: ScalarStyle,
         tag: Option<&Tag>,
     ) -> Self {
-        Scalar::parse_from_cow_and_metadata(v, style, tag).map_or_else(
+        Scalar::parse_from_cow_and_metadata(v, style, tag.map(Cow::Borrowed).as_ref()).map_or_else(
             || Self {
                 data: YamlData::BadValue,
                 span: Span::default(),

--- a/saphyr/src/annotated/marked_yaml_owned.rs
+++ b/saphyr/src/annotated/marked_yaml_owned.rs
@@ -139,7 +139,7 @@ impl LoadableYamlNode<'_> for MarkedYamlOwned {
                 Yaml::Alias(x) => YamlDataOwned::Alias(x),
                 Yaml::BadValue => YamlDataOwned::BadValue,
                 Yaml::Representation(v, style, tag) => {
-                    YamlDataOwned::Representation(v.to_string(), style, tag)
+                    YamlDataOwned::Representation(v.to_string(), style, tag.map(Cow::into_owned))
                 }
                 Yaml::Value(x) => YamlDataOwned::Value(x.into_owned()),
             },

--- a/saphyr/src/annotated/marked_yaml_owned.rs
+++ b/saphyr/src/annotated/marked_yaml_owned.rs
@@ -79,7 +79,7 @@ impl MarkedYamlOwned {
     pub fn value_from_cow_and_metadata(
         v: Cow<'_, str>,
         style: ScalarStyle,
-        tag: Option<&Tag>,
+        tag: Option<&Cow<'_, Tag>>,
     ) -> Self {
         ScalarOwned::parse_from_cow_and_metadata(v, style, tag).map_or_else(
             || Self {

--- a/saphyr/src/annotated/yaml_data.rs
+++ b/saphyr/src/annotated/yaml_data.rs
@@ -58,7 +58,7 @@ where
     /// [`is_boolean`]: YamlData::is_boolean
     /// [`as_integer`]: YamlData::as_integer
     /// [`into_floating_point`]: YamlData::into_floating_point
-    Representation(Cow<'input, str>, ScalarStyle, Option<Tag>),
+    Representation(Cow<'input, str>, ScalarStyle, Option<Cow<'input, Tag>>),
     /// The resolved value from the representation.
     Value(Scalar<'input>),
     /// YAML sequence, can be accessed as a `Vec`.

--- a/saphyr/src/emitter.rs
+++ b/saphyr/src/emitter.rs
@@ -7,6 +7,7 @@ use crate::{
     yaml::{Mapping, Yaml},
     Scalar,
 };
+use std::borrow::Cow;
 use std::convert::From;
 use std::error::Error;
 use std::fmt::{self, Display};
@@ -244,10 +245,16 @@ impl<'a> YamlEmitter<'a> {
             Yaml::Value(Scalar::FloatingPoint(ref v)) => Ok(write!(self.writer, "{v}")?),
             Yaml::Value(Scalar::Null) | Yaml::BadValue => Ok(write!(self.writer, "~")?),
             Yaml::Representation(ref v, style, ref tag) => {
-                if let Some(Tag {
-                    ref handle,
-                    ref suffix,
-                }) = tag
+                if let Some(
+                    Cow::Owned(Tag {
+                        ref handle,
+                        ref suffix,
+                    })
+                    | Cow::Borrowed(Tag {
+                        ref handle,
+                        ref suffix,
+                    }),
+                ) = tag
                 {
                     write!(self.writer, "{handle}!{suffix} ")?;
                 }

--- a/saphyr/src/loader.rs
+++ b/saphyr/src/loader.rs
@@ -1,6 +1,6 @@
 //! The default loader.
 
-use std::{borrow::Cow, collections::BTreeMap, marker::PhantomData, sync::Arc};
+use std::{collections::BTreeMap, marker::PhantomData, sync::Arc};
 
 use hashlink::LinkedHashMap;
 use saphyr_parser::{
@@ -266,7 +266,7 @@ where
                 let node = if self.early_parse {
                     Yaml::value_from_cow_and_metadata(v, style, tag.as_ref())
                 } else {
-                    Yaml::Representation(v, style, tag.map(Cow::Owned))
+                    Yaml::Representation(v, style, tag)
                 };
                 self.insert_new_node((Node::from_bare_yaml(node).with_span(span), aid));
             }

--- a/saphyr/src/loader.rs
+++ b/saphyr/src/loader.rs
@@ -1,6 +1,6 @@
 //! The default loader.
 
-use std::{collections::BTreeMap, marker::PhantomData, sync::Arc};
+use std::{borrow::Cow, collections::BTreeMap, marker::PhantomData, sync::Arc};
 
 use hashlink::LinkedHashMap;
 use saphyr_parser::{
@@ -266,7 +266,7 @@ where
                 let node = if self.early_parse {
                     Yaml::value_from_cow_and_metadata(v, style, tag.as_ref())
                 } else {
-                    Yaml::Representation(v, style, tag)
+                    Yaml::Representation(v, style, tag.map(Cow::Owned))
                 };
                 self.insert_new_node((Node::from_bare_yaml(node).with_span(span), aid));
             }

--- a/saphyr/src/macros.rs
+++ b/saphyr/src/macros.rs
@@ -177,7 +177,7 @@ impl< $( $generic ),+ > $yaml $(where $($whereclause)+)? {
         style: ScalarStyle,
         tag: Option<&Tag>,
     ) -> Self {
-        Scalar::parse_from_cow_and_metadata(v, style, tag).map_or(Self::BadValue, Self::Value)
+        Scalar::parse_from_cow_and_metadata(v, style, tag.map(Cow::Borrowed).as_ref()).map_or(Self::BadValue, Self::Value)
     }
 }
     );

--- a/saphyr/src/macros.rs
+++ b/saphyr/src/macros.rs
@@ -107,7 +107,7 @@ impl $(< $( $generic ),+ >)? $yaml $(where $($whereclause)+)? {
         match self.take() {
             Self::Representation(value, style, tag) => {
                 if let Some(scalar) =
-                    $scalartype::parse_from_cow_and_metadata(value.into(), style, tag.as_ref())
+                    $scalartype::parse_from_cow_and_metadata(value.into(), style, tag.map(std::borrow::Cow::Owned).as_ref())
                 {
                     *self = Self::Value(scalar);
                     true
@@ -164,7 +164,7 @@ impl< $( $generic ),+ > $yaml $(where $($whereclause)+)? {
         match self.take() {
             Self::Representation(value, style, tag) => {
                 if let Some(scalar) =
-                    $scalartype::parse_from_cow_and_metadata(value.into(), style, tag.as_ref().map(|v| &**v))
+                    $scalartype::parse_from_cow_and_metadata(value.into(), style, tag.as_ref())
                 {
                     *self = Self::Value(scalar);
                     true
@@ -227,7 +227,7 @@ impl< $( $generic ),+ > $yaml $(where $($whereclause)+)? {
     pub fn value_from_cow_and_metadata(
         v: Cow<'input, str>,
         style: ScalarStyle,
-        tag: Option<&Tag>,
+        tag: Option<&Cow<'input, Tag>>,
     ) -> Self {
         Scalar::parse_from_cow_and_metadata(v, style, tag).map_or(Self::BadValue, Self::Value)
     }

--- a/saphyr/src/scalar.rs
+++ b/saphyr/src/scalar.rs
@@ -107,21 +107,15 @@ impl<'input> Scalar<'input> {
     pub fn parse_from_cow_and_metadata(
         v: Cow<'input, str>,
         style: ScalarStyle,
-        tag: Option<&Cow<Tag>>,
+        tag: Option<&Tag>,
     ) -> Option<Self> {
         if style != ScalarStyle::Plain {
             // Any quoted scalar is a string.
             Some(Self::String(v))
-        } else if let Some(
-            Cow::Owned(Tag {
-                ref handle,
-                ref suffix,
-            })
-            | Cow::Borrowed(Tag {
-                ref handle,
-                ref suffix,
-            }),
-        ) = tag
+        } else if let Some(Tag {
+            ref handle,
+            ref suffix,
+        }) = tag
         {
             if handle == "tag:yaml.org,2002:" {
                 match suffix.as_ref() {
@@ -233,8 +227,7 @@ impl ScalarOwned {
         style: ScalarStyle,
         tag: Option<&Tag>,
     ) -> Option<Self> {
-        Scalar::parse_from_cow_and_metadata(v, style, tag.map(Cow::Borrowed).as_ref())
-            .map(Scalar::into_owned)
+        Scalar::parse_from_cow_and_metadata(v, style, tag).map(Scalar::into_owned)
     }
 
     /// Parse a scalar node representation into a [`ScalarOwned`].

--- a/saphyr/src/scalar.rs
+++ b/saphyr/src/scalar.rs
@@ -245,12 +245,6 @@ impl ScalarOwned {
 
 impl<'input> From<&'input ScalarOwned> for Scalar<'input> {
     fn from(value: &'input ScalarOwned) -> Self {
-        match value {
-            ScalarOwned::Null => Scalar::Null,
-            ScalarOwned::Boolean(bool) => Scalar::Boolean(*bool),
-            ScalarOwned::Integer(int) => Scalar::Integer(*int),
-            ScalarOwned::FloatingPoint(ordered_float) => Scalar::FloatingPoint(*ordered_float),
-            ScalarOwned::String(str) => Scalar::String(Cow::Borrowed(str)),
-        }
+        value.as_scalar()
     }
 }

--- a/saphyr/src/scalar.rs
+++ b/saphyr/src/scalar.rs
@@ -69,12 +69,13 @@ impl<'input> Scalar<'input> {
     /// # Return
     /// Returns the parsed [`Scalar`].
     ///
-    /// If `tag` is not [`None`] and `v` cannot be parsed as that specific tag, this function returns
-    /// `None`.
+    /// If `tag` is not [`None`] and `v` cannot be parsed as that specific tag, this function
+    /// returns `None`.
     ///
     /// # Examples
     /// ```
     /// # use saphyr::{Scalar, ScalarStyle, Tag};
+    /// use std::borrow::Cow::Owned;
     /// assert_eq!(
     ///     Scalar::parse_from_cow_and_metadata("123".into(), ScalarStyle::Plain, None),
     ///     Some(Scalar::Integer(123))
@@ -83,7 +84,7 @@ impl<'input> Scalar<'input> {
     ///     Scalar::parse_from_cow_and_metadata(
     ///         "123".into(),
     ///         ScalarStyle::Plain,
-    ///         Some(&Tag { handle: "tag:yaml.org,2002:".into(), suffix: "str".into() })
+    ///         Some(&Owned(Tag { handle: "tag:yaml.org,2002:".into(), suffix: "str".into() }))
     ///     ),
     ///     Some(Scalar::String("123".into()))
     /// );
@@ -91,7 +92,7 @@ impl<'input> Scalar<'input> {
     ///     Scalar::parse_from_cow_and_metadata(
     ///         "not a number".into(),
     ///         ScalarStyle::Plain,
-    ///         Some(&Tag { handle: "tag:yaml.org,2002:".into(), suffix: "int".into() })
+    ///         Some(&Owned(Tag { handle: "tag:yaml.org,2002:".into(), suffix: "int".into() }))
     ///     ),
     ///     None
     /// );
@@ -99,7 +100,7 @@ impl<'input> Scalar<'input> {
     ///     Scalar::parse_from_cow_and_metadata(
     ///         "No".into(),
     ///         ScalarStyle::Plain,
-    ///         Some(&Tag { handle: "tag:yaml.org,2002:".into(), suffix: "bool".into() })
+    ///         Some(&Owned(Tag { handle: "tag:yaml.org,2002:".into(), suffix: "bool".into() }))
     ///     ),
     ///     None
     /// );
@@ -107,7 +108,7 @@ impl<'input> Scalar<'input> {
     pub fn parse_from_cow_and_metadata(
         v: Cow<'input, str>,
         style: ScalarStyle,
-        tag: Option<&Tag>,
+        tag: Option<&Cow<'input, Tag>>,
     ) -> Option<Self> {
         if style != ScalarStyle::Plain {
             // Any quoted scalar is a string.
@@ -115,7 +116,7 @@ impl<'input> Scalar<'input> {
         } else if let Some(Tag {
             ref handle,
             ref suffix,
-        }) = tag
+        }) = tag.map(Cow::as_ref)
         {
             if handle == "tag:yaml.org,2002:" {
                 match suffix.as_ref() {
@@ -225,7 +226,7 @@ impl ScalarOwned {
     pub fn parse_from_cow_and_metadata(
         v: Cow<'_, str>,
         style: ScalarStyle,
-        tag: Option<&Tag>,
+        tag: Option<&Cow<'_, Tag>>,
     ) -> Option<Self> {
         Scalar::parse_from_cow_and_metadata(v, style, tag).map(Scalar::into_owned)
     }

--- a/saphyr/src/scalar.rs
+++ b/saphyr/src/scalar.rs
@@ -107,15 +107,21 @@ impl<'input> Scalar<'input> {
     pub fn parse_from_cow_and_metadata(
         v: Cow<'input, str>,
         style: ScalarStyle,
-        tag: Option<&Tag>,
+        tag: Option<&Cow<Tag>>,
     ) -> Option<Self> {
         if style != ScalarStyle::Plain {
             // Any quoted scalar is a string.
             Some(Self::String(v))
-        } else if let Some(Tag {
-            ref handle,
-            ref suffix,
-        }) = tag
+        } else if let Some(
+            Cow::Owned(Tag {
+                ref handle,
+                ref suffix,
+            })
+            | Cow::Borrowed(Tag {
+                ref handle,
+                ref suffix,
+            }),
+        ) = tag
         {
             if handle == "tag:yaml.org,2002:" {
                 match suffix.as_ref() {
@@ -227,7 +233,8 @@ impl ScalarOwned {
         style: ScalarStyle,
         tag: Option<&Tag>,
     ) -> Option<Self> {
-        Scalar::parse_from_cow_and_metadata(v, style, tag).map(Scalar::into_owned)
+        Scalar::parse_from_cow_and_metadata(v, style, tag.map(Cow::Borrowed).as_ref())
+            .map(Scalar::into_owned)
     }
 
     /// Parse a scalar node representation into a [`ScalarOwned`].

--- a/saphyr/src/scalar.rs
+++ b/saphyr/src/scalar.rs
@@ -242,3 +242,15 @@ impl ScalarOwned {
         Scalar::parse_from_cow(v).into_owned()
     }
 }
+
+impl<'input> From<&'input ScalarOwned> for Scalar<'input> {
+    fn from(value: &'input ScalarOwned) -> Self {
+        match value {
+            ScalarOwned::Null => Scalar::Null,
+            ScalarOwned::Boolean(bool) => Scalar::Boolean(*bool),
+            ScalarOwned::Integer(int) => Scalar::Integer(*int),
+            ScalarOwned::FloatingPoint(ordered_float) => Scalar::FloatingPoint(*ordered_float),
+            ScalarOwned::String(str) => Scalar::String(Cow::Borrowed(str)),
+        }
+    }
+}

--- a/saphyr/src/yaml.rs
+++ b/saphyr/src/yaml.rs
@@ -48,7 +48,7 @@ pub enum Yaml<'input> {
     /// [`is_boolean`]: Yaml::is_boolean
     /// [`as_integer`]: Yaml::as_integer
     /// [`into_floating_point`]: Yaml::into_floating_point
-    Representation(Cow<'input, str>, ScalarStyle, Option<Tag>),
+    Representation(Cow<'input, str>, ScalarStyle, Option<Cow<'input, Tag>>),
     /// The resolved value from the representation.
     Value(Scalar<'input>),
     /// YAML sequence, can be accessed as a `Vec`.
@@ -220,9 +220,11 @@ fn hash_str_as_yaml_string<H: Hasher>(key: &str, mut hasher: H) -> u64 {
 impl<'input> From<&'input YamlOwned> for Yaml<'input> {
     fn from(value: &'input YamlOwned) -> Self {
         match value {
-            YamlOwned::Representation(str, scalar_style, tag) => {
-                Yaml::Representation(Cow::Borrowed(str), *scalar_style, tag.clone())
-            }
+            YamlOwned::Representation(str, scalar_style, tag) => Yaml::Representation(
+                Cow::Borrowed(str),
+                *scalar_style,
+                tag.as_ref().map(Cow::Borrowed),
+            ),
             YamlOwned::Value(scalar_owned) => Yaml::Value(scalar_owned.into()),
             YamlOwned::Sequence(yaml_owneds) => Yaml::Sequence(
                 yaml_owneds

--- a/saphyr/src/yaml_owned.rs
+++ b/saphyr/src/yaml_owned.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::module_name_repetitions)]
 
 use std::{
+    borrow::Cow,
     hash::{BuildHasher, Hasher},
     ops::{Index, IndexMut},
 };
@@ -156,7 +157,7 @@ impl LoadableYamlNode<'_> for YamlOwned {
             Yaml::Mapping(_) => Self::Mapping(MappingOwned::new()),
 
             Yaml::Representation(cow, scalar_style, tag) => {
-                Self::Representation(cow.into(), scalar_style, tag)
+                Self::Representation(cow.into(), scalar_style, tag.map(Cow::into_owned))
             }
             Yaml::Value(scalar) => Self::Value(scalar.into_owned()),
             Yaml::Alias(x) => Self::Alias(x),


### PR DESCRIPTION
This implements `From<&'input YamlOwned>` for `Yaml<'input>` and `From<&'input ScalarOwned>` for `Scalar<'input>`.
The main motivation for this was storing `YamlOwned`s in structs and then needing to interface with apis that expected `Yaml`s. 
This also provides a way to actually use `YamlEmitter::dump` with `YamlOwned`s by converting them to `Yaml` first.

Theres a part of me that wants this to be an `AsRef` impl instead of a `From` impl but, because `Yaml::Representation` stores owned `Tag`s it necessitates cloning, and so I made it a `From` impl.