### PR TITLE
Restrict Parsing of `inf`, `infinity`, and `nan` barewords

### DIFF
--- a/saphyr/CHANGELOG.md
+++ b/saphyr/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Breaking Changes**:
 
+- No longer parse any capitalization of `inf`, or `infinity` as `f64::INFINITY`
 - Parse `.NaN` as float instead of `NaN`.
 
 ## v0.0.4

--- a/saphyr/src/loader.rs
+++ b/saphyr/src/loader.rs
@@ -372,6 +372,9 @@ pub(crate) fn parse_f64(v: &str) -> Option<f64> {
         ".inf" | ".Inf" | ".INF" | "+.inf" | "+.Inf" | "+.INF" => Some(f64::INFINITY),
         "-.inf" | "-.Inf" | "-.INF" => Some(f64::NEG_INFINITY),
         ".nan" | ".NaN" | ".NAN" => Some(f64::NAN),
-        _ => v.parse::<f64>().ok(),
+        // Test that `v` contains a digit so as not to pass in strings like `inf`,
+        // which rust will parse as a float.
+        _ if v.as_bytes().iter().any(u8::is_ascii_digit) => v.parse::<f64>().ok(),
+        _ => None,
     }
 }


### PR DESCRIPTION
> [!NOTE]
> This PR is a port of [yaml-rust2!51](https://github.com/Ethiraric/yaml-rust2/pull/51). Some changes have been made, implementing notes from @Ethiraric, and some minor name changes. Note that, while similar, the description here is different.

# Summary

Currently, we use Rust's standard `f64` parsing to determine if a value is a float. If Rust considers a given string to be a float, it is parsed as one.

Rust considers any capitalization of the strings `inf`, `infinity`, and `nan` to be floats, while YAML does not. This PR brings our behavior inline with YAML's definition of a float.

# Details

The [Rust docs](https://doc.rust-lang.org/std/primitive.f64.html#impl-FromStr-for-f64) provide the following EBNF grammar for what it considers to be valid floats:

```EBNF
Float  ::= Sign? ( 'inf' | 'infinity' | 'nan' | Number )
Number ::= ( Digit+ |
             Digit+ '.' Digit* |
             Digit* '.' Digit+ ) Exp?
Exp    ::= 'e' Sign? Digit+
Sign   ::= [+-]
Digit  ::= [0-9]
```

The [YAML specification](https://yaml.org/spec/1.2.2/#10214-floating-point) provides this, conflicting, definition (in 10.2.1.4):
> Either `0`, `.inf`, `-.inf`, `.nan`, or scientific notation matching the regular expression `-? [1-9] ( \. [0-9]* [1-9] )? ( e [-+] [1-9] [0-9]* )?`.

# Resolution

When parsing floats, before forwarding to Rust's parser, we now check if any character in the string is a digit. Since the list of cases we need to cover is `0` or `-? [1-9] ( \. [0-9]* [1-9] )? ( e [-+] [1-9] [0-9]* )?`, any valid string will contain a digit.

# Tests

Included in this PR is a back test that generates a document with several offending values, `tests::basic::test_nominal_float_parse`.

# Checks

```sh
just before_commit
```
Was run and passed before this PR was submitted (sorry about that!)
