### PR TITLE
Add custom tags support.

### DIFF
--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -101,6 +101,21 @@ pub struct Tag {
     pub suffix: String,
 }
 
+impl Tag {
+    /// Returns whether the tag is a YAML tag from the core schema (`!!str`, `!!int`, ...).
+    ///
+    /// The YAML specification specifies [a list of
+    /// tags](https://yaml.org/spec/1.2.2/#103-core-schema) for the Core Schema. This function
+    /// checks whether _the handle_ (but not the suffix) is the handle for the YAML Core Schema.
+    ///
+    /// # Return
+    /// Returns `true` if the handle is `tag:yaml.org,2002`, `false` otherwise.
+    #[must_use]
+    pub fn is_yaml_core_schema(&self) -> bool {
+        self.handle == "tag:yaml.org,2002:"
+    }
+}
+
 impl Display for Tag {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}!{}", self.handle, self.suffix)

--- a/saphyr/CHANGELOG.md
+++ b/saphyr/CHANGELOG.md
@@ -5,6 +5,17 @@
 **Breaking Changes**:
 
 - 234c69c9..374d8920: Use `Cow`s for `Tag`s
+- Perform parsing of scalars with unknown tags according to the core schema.
+  Previously, `!foo 42` would yield a `Scalar::String("42")` becuse the tag
+  wasn't known. It will now yield a `Scalar::Integer(42)`. `!!str 42` will
+  still yield a `Scalar::String`.
+- Parsing a scalar with an unknown Core Schema tag (e.g.: `!!unknown`) now
+  results in a `BadValue` rather than a `String`.
+- Expose custom YAML tags as a variant of `Yaml`/`YamlData` objects. The
+  biggest pain point for existing users is probably the inclusion of
+  `Yaml::Tagged`, which will break existing `match`es on `Yaml`. Details about
+  how `saphyr` handles YAML tags can be found on the library documentation.
+- Add `into_tagged` as a `LoadableYamlNode` requirement.
 
 **Features**:
 
@@ -12,6 +23,7 @@
   and borrowed versions of `Yaml` and `Scalar`.
 - `parse_core_schema_fp` for parsing floating point values according to the
   YAML core schema.
+- Support for custom tags.
 
 **Fixes**:
 

--- a/saphyr/src/annotated/marked_yaml.rs
+++ b/saphyr/src/annotated/marked_yaml.rs
@@ -133,6 +133,9 @@ impl<'input> LoadableYamlNode<'input> for MarkedYaml<'input> {
                 Yaml::Alias(x) => YamlData::Alias(x),
                 Yaml::BadValue => YamlData::BadValue,
                 Yaml::Representation(v, style, tag) => YamlData::Representation(v, style, tag),
+                Yaml::Tagged(tag, node) => {
+                    YamlData::Tagged(tag, Box::new(Self::from_bare_yaml(*node)))
+                }
                 Yaml::Value(x) => YamlData::Value(x),
             },
         }
@@ -148,6 +151,13 @@ impl<'input> LoadableYamlNode<'input> for MarkedYaml<'input> {
 
     fn is_badvalue(&self) -> bool {
         self.data.is_badvalue()
+    }
+
+    fn into_tagged(self, tag: Cow<'input, Tag>) -> Self {
+        Self {
+            span: self.span,
+            data: YamlData::Tagged(tag, Box::new(self)),
+        }
     }
 
     fn sequence_mut(&mut self) -> &mut Vec<Self> {

--- a/saphyr/src/annotated/marked_yaml_owned.rs
+++ b/saphyr/src/annotated/marked_yaml_owned.rs
@@ -141,6 +141,9 @@ impl LoadableYamlNode<'_> for MarkedYamlOwned {
                 Yaml::Representation(v, style, tag) => {
                     YamlDataOwned::Representation(v.to_string(), style, tag.map(Cow::into_owned))
                 }
+                Yaml::Tagged(tag, node) => {
+                    YamlDataOwned::Tagged(tag.into_owned(), Box::new(Self::from_bare_yaml(*node)))
+                }
                 Yaml::Value(x) => YamlDataOwned::Value(x.into_owned()),
             },
         }
@@ -156,6 +159,13 @@ impl LoadableYamlNode<'_> for MarkedYamlOwned {
 
     fn is_badvalue(&self) -> bool {
         self.data.is_badvalue()
+    }
+
+    fn into_tagged(self, tag: Cow<'_, Tag>) -> Self {
+        Self {
+            span: self.span,
+            data: YamlDataOwned::Tagged(tag.into_owned(), Box::new(self)),
+        }
     }
 
     fn sequence_mut(&mut self) -> &mut Vec<Self> {

--- a/saphyr/src/annotated/yaml_data.rs
+++ b/saphyr/src/annotated/yaml_data.rs
@@ -48,6 +48,9 @@ where
     /// (e.g.: [`is_boolean`], [`as_integer`], [`into_floating_point`], ...) will always return
     /// [`None`].
     ///
+    /// Resolving the representation to its scalar value can either yield a [`Value`] or a
+    /// [`Tagged`] variant, depending on whether the scalar is tagged.
+    ///
     /// This variant is only meant:
     ///   - As an optimization, when lazy-parsing is preferred.
     ///   - As a more generic way of handling keys in [`Mapping`]s (if user-defined key duplication
@@ -55,6 +58,8 @@ where
     ///
     /// [`Mapping`]: YamlData::Mapping
     /// [`Representation`]: YamlData::Representation
+    /// [`Value`]: YamlData::Value
+    /// [`Tagged`]: YamlData::Tagged
     /// [`is_boolean`]: YamlData::is_boolean
     /// [`as_integer`]: YamlData::as_integer
     /// [`into_floating_point`]: YamlData::into_floating_point
@@ -95,6 +100,10 @@ where
     /// [scalar style]: ScalarStyle
     /// [`OrderedFloat`]: ordered_float::OrderedFloat
     Mapping(AnnotatedMapping<'input, Node>),
+    /// A tagged node.
+    ///
+    /// Tags can be applied to any node, whether a scalar or a collection.
+    Tagged(Cow<'input, Tag>, Box<Node>),
     /// Alias, not fully supported yet.
     Alias(usize),
     /// A variant used when parsing the representation of a scalar node fails.

--- a/saphyr/src/annotated/yaml_data_owned.rs
+++ b/saphyr/src/annotated/yaml_data_owned.rs
@@ -42,6 +42,12 @@ where
     ///
     /// [`YamlData::Mapping`]: `crate::YamlData::Mapping`
     Mapping(AnnotatedMappingOwned<Node>),
+    /// A tagged node.
+    ///
+    /// See [`YamlData::Tagged`].
+    ///
+    /// [`YamlData::Tagged`]: `crate::YamlData::Tagged`
+    Tagged(Tag, Box<Node>),
     /// Alias, not fully supported yet.
     ///
     /// See [`YamlData::Alias`].

--- a/saphyr/src/lib.rs
+++ b/saphyr/src/lib.rs
@@ -27,6 +27,85 @@
 //! emitter.dump(doc).unwrap(); // dump the YAML object to a String
 //! ```
 //!
+//! # YAML object types
+//!
+//! There are multiple YAML objects in this library which share most features but differ in
+//! usecase:
+//!   - [`Yaml`]: The go-to YAML object. It contains YAML data and borrows from the input.
+//!   - [`YamlOwned`]: An owned version of [`Yaml`]. It does not borrow from the input and can be
+//!     used when tieing the object to the input is undesireable or would introduce unnecessary
+//!     lifetimes.
+//!   - [`MarkedYaml`]: A YAML object with added [`Marker`]s for the beginning and end of the YAML
+//!     object in the input.
+//!   - [`MarkedYamlOwned`]: An owned version of [`MarkedYaml`]. It does not borrow from the input
+//!     and can be used when tieing the object to the input is undesireable or would introduce
+//!     unnecessary lifetimes.
+//!
+//! All of these share the same inspection methods (`is_boolean`, `as_str`, `into_vec`, ...) with
+//! some variants between owned and borrowing versions.
+//!
+//! They also contain the same variants. [`Yaml`] and [`YamlOwned`] are `enums`, while annotated
+//! objects ([`MarkedYaml`], [`MarkedYamlOwned`]) are structures with a `.data` enum
+//! (see [`YamlData`], [`YamlDataOwned`]).
+//!
+//! # YAML Tags
+//! ## YAML Core Schema tags (`!!str`, `!!int`, `!!float`, ...)
+//! `saphyr` is aware of the [YAML Core Schema tags](https://yaml.org/spec/1.2.2/#103-core-schema)
+//! and will parse scalars accordingly. This is handled in [`Scalar::parse_from_cow_and_metadata`].
+//! Should a scalar be explicitly tagged with a tag whose handle is that of the Core Schema,
+//! `saphyr` will attempt to parse it as the given type. If parsing fails (e.g.: `!!int foo`), a
+//! [`BadValue`] will be returned. If however the tag is unknown, the scalar will be parsed as a
+//! string (e.g.: `!!unk 12`).
+//!
+//! Core Schema tags on collections are ignored, since the syntax disallows any ambiguity in
+//! parsing.
+//!
+//! Upon parsing, the core schema tags are not preserved. If you need the tags on scalar preserved,
+//! you may disable [`early_parse`]. This will cause all scalars to use the [`Representation`]
+//! variant which preserves the tags. There is currently no way to preserve Core Schema tags on
+//! collections.
+//!
+//! ## User-defined tags
+//! The YAML specification does not explicitly specify how user-defined tags should be parsed
+//! ([10.4](https://yaml.org/spec/1.2.2/#104-other-schemas)). `saphyr` is very conservative on this
+//! and will leave tags as-is. They are wrapped in a [`Tagged`] variant where you can freely
+//! inspect the tag alongside the tagged node.
+//!
+//! **The tagged node will be parsed as an untagged node.** What this means is that `13` will be
+//! parsed as an integer, `foo` as a string, ... etc. See the related discussion [on
+//! Github](https://github.com/saphyr-rs/saphyr/issues/4#issuecomment-2899433908) for more context
+//! on the decision.
+//!
+//! Examples:
+//! ```
+//! # use saphyr::{LoadableYamlNode, Tag, Yaml};
+//! # let parse = |s| Yaml::load_from_str(s).unwrap().into_iter().next().unwrap();
+//! #
+//! assert!(matches!(parse("!custom 3"),     Yaml::Tagged(_tag, node) if node.is_integer()));
+//! assert!(matches!(parse("!custom 'foo'"), Yaml::Tagged(_tag, node) if node.is_string()));
+//! assert!(matches!(parse("!custom foo"),   Yaml::Tagged(_tag, node) if node.is_string()));
+//! assert!(matches!(parse("!custom ~"),     Yaml::Tagged(_tag, node) if node.is_null()));
+//! assert!(matches!(parse("!custom '3'"),   Yaml::Tagged(_tag, node) if node.is_string()));
+//! ```
+//!
+//! User-defined tags can be applied to any node, whether a collection or a scalar. They do not
+//! change the resolution behavior of inner nodes.
+//! ```
+//! # use saphyr::{LoadableYamlNode, Tag, Yaml};
+//! # let parse = |s| Yaml::load_from_str(s).unwrap().into_iter().next().unwrap();
+//! #
+//! assert!(matches!(parse("!custom [foo]"),     Yaml::Tagged(_tag, node) if node.is_sequence()));
+//! assert!(matches!(parse("!custom {a:b}"),     Yaml::Tagged(_tag, node) if node.is_mapping()));
+//!
+//! let node = parse("!custom [1, foo, !!str 3, !custom 3]");
+//! let Yaml::Tagged(_, seq) = node else { panic!() };
+//! assert!(seq.is_sequence());
+//! assert!(seq[0].is_integer());
+//! assert!(seq[1].is_string());
+//! assert!(seq[2].is_string());
+//! assert!(matches!(&seq[3], Yaml::Tagged(_tag, node) if node.is_integer()));
+//! ```
+//!
 //! # Features
 //! **Note:** With all features disabled, this crate's MSRV is `1.65.0`.
 //!
@@ -34,6 +113,16 @@
 //! Enables encoding-aware decoding of Yaml documents.
 //!
 //! The MSRV for this feature is `1.70.0`.
+//!
+//! [`MarkedYaml`]: crate::MarkedYaml
+//! [`MarkedYamlOwned`]: crate::MarkedYamlOwned
+//! [`Marker`]: crate::Marker
+//! [`YamlData`]: crate::YamlData
+//! [`YamlDataOwned`]: crate::YamlDataOwned
+//! [`BadValue`]: Yaml::BadValue
+//! [`Representation`]: Yaml::Representation
+//! [`Tagged`]: Yaml::Tagged
+//! [`early_parse`]: crate::YamlLoader::early_parse
 
 #![warn(missing_docs, clippy::pedantic)]
 

--- a/saphyr/tests/tags.rs
+++ b/saphyr/tests/tags.rs
@@ -1,0 +1,132 @@
+use saphyr::{LoadableYamlNode, Yaml};
+
+#[test]
+fn f() {
+    use saphyr::Tag;
+    let parse = |s| Yaml::load_from_str(s).unwrap().into_iter().next().unwrap();
+
+    let custom_tag = &Tag {
+        handle: "!".into(),
+        suffix: "custom".into(),
+    };
+    assert!(
+        matches!(parse("!custom 3"), Yaml::Tagged(tag, node) if tag.as_ref() == custom_tag && node.is_integer())
+    );
+    assert!(
+        matches!(parse("!custom 'foo'"), Yaml::Tagged(tag, node) if tag.as_ref() == custom_tag && node.is_string())
+    );
+    assert!(
+        matches!(parse("!custom foo"), Yaml::Tagged(tag, node) if tag.as_ref() == custom_tag && node.is_string())
+    );
+    assert!(
+        matches!(parse("!custom ~"), Yaml::Tagged(tag, node) if tag.as_ref() == custom_tag && node.is_null())
+    );
+    assert!(
+        matches!(parse("!custom '3'"), Yaml::Tagged(tag, node) if tag.as_ref() == custom_tag && node.is_string())
+    );
+}
+
+#[test]
+fn on_scalar() {
+    let s = "
+- !degree 45
+- foo
+";
+    let docs = Yaml::load_from_str(s).unwrap();
+    let doc = &docs[0];
+
+    assert!(doc.is_sequence());
+    let items = doc.as_sequence().unwrap();
+
+    let foo = &items[1];
+    assert!(foo.as_str().is_some_and(|s| s == "foo"));
+
+    let degrees = &items[0];
+    let Yaml::Tagged(tag, degree) = degrees else {
+        panic!("Not a Tagged")
+    };
+    let tag = tag.as_ref();
+    assert!(tag.handle == "!");
+    assert!(tag.suffix == "degree");
+    assert!(degree.as_integer().is_some_and(|x| x == 45));
+}
+
+#[test]
+fn on_collection() {
+    let s = "
+- !degrees [45, 30]
+- foo
+";
+    let docs = Yaml::load_from_str(s).unwrap();
+    let doc = &docs[0];
+
+    assert!(doc.is_sequence());
+    let items = doc.as_sequence().unwrap();
+
+    let foo = &items[1];
+    assert!(foo.as_str().is_some_and(|s| s == "foo"));
+
+    let degrees = &items[0];
+    let Yaml::Tagged(tag, degrees) = degrees else {
+        panic!("Not a Tagged")
+    };
+    let tag = tag.as_ref();
+    assert!(tag.handle == "!");
+    assert!(tag.suffix == "degrees");
+
+    let arr = degrees.as_sequence().unwrap();
+    assert!(arr[0].as_integer().is_some_and(|x| x == 45));
+    assert!(arr[1].as_integer().is_some_and(|x| x == 30));
+}
+
+#[test]
+fn on_collection_and_item() {
+    let s = "
+- !degrees [45, !inner_tag 30, 'untagged_string']
+- foo
+";
+    let docs = Yaml::load_from_str(s).unwrap();
+    let doc = &docs[0];
+
+    assert!(doc.is_sequence());
+    let items = doc.as_sequence().unwrap();
+
+    let foo = &items[1];
+    assert!(foo.as_str().is_some_and(|s| s == "foo"));
+
+    let collection = &items[0];
+    let Yaml::Tagged(tag, degrees) = collection else {
+        panic!("Not a Tagged")
+    };
+    let tag = tag.as_ref();
+    assert!(tag.handle == "!");
+    assert!(tag.suffix == "degrees");
+
+    let arr = degrees.as_sequence().unwrap();
+    assert!(arr[0].as_integer().is_some_and(|x| x == 45));
+    assert!(arr[2].as_str().is_some_and(|s| s == "untagged_string"));
+
+    let Yaml::Tagged(ref inner_tag, ref degree) = arr[1] else {
+        panic!("Not a tagged")
+    };
+    assert!(inner_tag.handle == "!");
+    assert!(inner_tag.suffix == "inner_tag");
+    assert!(degree.as_integer().is_some_and(|x| x == 30));
+}
+
+#[test]
+fn core_schema_collection_tag() {
+    let s = "
+- !!seq []
+- !!str 12
+- !!int 12
+";
+    let docs = Yaml::load_from_str(s).unwrap();
+    let doc = &docs[0];
+
+    assert!(doc.is_sequence());
+    let items = doc.as_sequence().unwrap();
+    assert!(items[0].as_sequence().is_some_and(Vec::is_empty));
+    assert!(items[1].as_str().is_some_and(|s| s == "12"));
+    assert!(items[2].as_integer().is_some_and(|i| i == 12));
+}


### PR DESCRIPTION
Fixes #4.

There are still tests missing for the emitter, but this should provide a strong baseline. You can see `saphyr/tests/tags.rs` and the added doccomments for `lib.rs` if you only want to review the API.

Do feel free to comment other tests you think of which may be interesting.