### PR TITLE
Export AnnotatedMappingOwned and AnnotatedSequenceOwned

### DIFF
--- a/saphyr/src/annotated.rs
+++ b/saphyr/src/annotated.rs
@@ -58,7 +58,7 @@ pub mod marked_yaml_owned;
 pub mod yaml_data;
 pub mod yaml_data_owned;
 
-pub use yaml_data::{AnnotatedMapping, AnnotatedSequence, AnnotatedYamlIter, YamlData};
+pub use yaml_data::{AnnotatedMapping, AnnotatedMappingOwned, AnnotatedSequence, AnnotatedSequenceOwned, AnnotatedYamlIter, YamlData};
 pub use yaml_data_owned::YamlDataOwned;
 
 /// A trait allowing for introspection in the hash types of the [`YamlData::Mapping`] variant.

--- a/saphyr/src/annotated.rs
+++ b/saphyr/src/annotated.rs
@@ -58,8 +58,8 @@ pub mod marked_yaml_owned;
 pub mod yaml_data;
 pub mod yaml_data_owned;
 
-pub use yaml_data::{AnnotatedMapping, AnnotatedMappingOwned, AnnotatedSequence, AnnotatedSequenceOwned, AnnotatedYamlIter, YamlData};
-pub use yaml_data_owned::YamlDataOwned;
+pub use yaml_data::{AnnotatedMapping, AnnotatedSequence, AnnotatedYamlIter, YamlData};
+pub use yaml_data_owned::{YamlDataOwned, AnnotatedMappingOwned, AnnotatedSequenceOwned};
 
 /// A trait allowing for introspection in the hash types of the [`YamlData::Mapping`] variant.
 ///

--- a/saphyr/src/lib.rs
+++ b/saphyr/src/lib.rs
@@ -139,8 +139,8 @@ mod yaml_owned;
 
 // Re-export main components.
 pub use crate::annotated::{
-    marked_yaml::MarkedYaml, marked_yaml_owned::MarkedYamlOwned, AnnotatedMapping, AnnotatedNode,
-    AnnotatedNodeOwned, AnnotatedSequence, AnnotatedYamlIter, YamlData, YamlDataOwned,
+    marked_yaml::MarkedYaml, marked_yaml_owned::MarkedYamlOwned, AnnotatedMapping, AnnotatedMappingOwned, AnnotatedNode,
+    AnnotatedNodeOwned, AnnotatedSequence, AnnotatedSequenceOwned, AnnotatedYamlIter, YamlData, YamlDataOwned,
 };
 pub use crate::emitter::{EmitError, YamlEmitter};
 pub use crate::loader::{LoadError, LoadableYamlNode, YamlLoader};


### PR DESCRIPTION
This PR just `pub use`s `AnnotatedMappingOwned` and `AnnotatedSequenceOwned`. These types are exposed as part of the public API when pattern matching over `YamlDataOwned`:

```rust
match yaml {
    YamlDataOwned::Mapping(mapping) => { /* I can access the mapping's methods here */ },
    ...
}
```

However, because the types aren't exposed, you can't e.g. write a function which takes `mapping` as a parameter.