### PR TITLE
Changes needed for everdiff v2

### DIFF
--- a/saphyr/examples/dump_yaml.rs
+++ b/saphyr/examples/dump_yaml.rs
@@ -1,4 +1,5 @@
-use saphyr::{LoadableYamlNode, Yaml};
+use saphyr::LoadableYamlNode;
+use saphyr::{MarkedYaml, YamlData};
 use std::env;
 use std::fs::File;
 use std::io::prelude::*;
@@ -9,14 +10,14 @@ fn print_indent(indent: usize) {
     }
 }
 
-fn dump_node(doc: &Yaml, indent: usize) {
-    match *doc {
-        Yaml::Sequence(ref v) => {
+fn dump_node(node: &MarkedYaml, indent: usize) {
+    match node.data {
+        YamlData::Sequence(ref v) => {
             for x in v {
                 dump_node(x, indent + 1);
             }
         }
-        Yaml::Mapping(ref h) => {
+        YamlData::Mapping(ref h) => {
             for (k, v) in h {
                 print_indent(indent);
                 println!("{k:?}:");
@@ -25,7 +26,6 @@ fn dump_node(doc: &Yaml, indent: usize) {
         }
         _ => {
             print_indent(indent);
-            println!("{doc:?}");
         }
     }
 }
@@ -36,7 +36,7 @@ fn main() {
     let mut s = String::new();
     f.read_to_string(&mut s).unwrap();
 
-    let docs = Yaml::load_from_str(&s).unwrap();
+    let docs = MarkedYaml::load_from_str(&s).unwrap();
     for doc in &docs {
         println!("---");
         dump_node(doc, 0);

--- a/saphyr/src/annotated.rs
+++ b/saphyr/src/annotated.rs
@@ -61,6 +61,8 @@ pub mod yaml_data_owned;
 pub use yaml_data::{AnnotatedMapping, AnnotatedSequence, AnnotatedYamlIter, YamlData};
 pub use yaml_data_owned::{AnnotatedMappingOwned, AnnotatedSequenceOwned, YamlDataOwned};
 
+use crate::{LoadableYamlNode, MarkedYaml, MarkedYamlOwned};
+
 /// A trait allowing for introspection in the hash types of the [`YamlData::Mapping`] variant.
 ///
 /// This trait must be implemented by annotated YAML objects.
@@ -95,4 +97,68 @@ pub trait AnnotatedNodeOwned: std::hash::Hash + std::cmp::Eq {
 
     /// See [`YamlData::parse_representation_recursive`].
     fn parse_representation_recursive(&mut self) -> bool;
+}
+
+/// A trait to index into a structure with an `Index`
+pub trait Indexable: Sized {
+    /// something important
+    fn get(&self, key: impl Index<Self>) -> Option<&Self>;
+}
+
+/// A trait to denote a type that can be used for indexing YAML
+pub trait Index<Y> {
+    /// something important
+    fn index_into(self, yaml: &Y) -> Option<&Y>;
+}
+
+impl Index<MarkedYamlOwned> for usize {
+    fn index_into(self, yaml: &MarkedYamlOwned) -> Option<&MarkedYamlOwned> {
+        if yaml.is_sequence() {
+            yaml.data.as_sequence_get(self)
+        } else {
+            None
+        }
+    }
+}
+
+impl<'input> Index<MarkedYaml<'input>> for usize {
+    fn index_into<'y>(self, yaml: &'y MarkedYaml<'input>) -> Option<&'y MarkedYaml<'input>> {
+        if yaml.is_sequence() {
+            yaml.data.as_sequence_get(self)
+        } else {
+            None
+        }
+    }
+}
+
+impl Index<MarkedYamlOwned> for &str {
+    fn index_into(self, yaml: &MarkedYamlOwned) -> Option<&MarkedYamlOwned> {
+        if yaml.is_mapping() {
+            yaml.data.as_mapping_get(self)
+        } else {
+            None
+        }
+    }
+}
+
+impl<'input> Index<MarkedYaml<'input>> for &str {
+    fn index_into<'y>(self, yaml: &'y MarkedYaml<'input>) -> Option<&'y MarkedYaml<'input>> {
+        if yaml.is_mapping() {
+            yaml.data.as_mapping_get(self)
+        } else {
+            None
+        }
+    }
+}
+
+impl Index<MarkedYamlOwned> for String {
+    fn index_into(self, yaml: &MarkedYamlOwned) -> Option<&MarkedYamlOwned> {
+        self.as_str().index_into(yaml)
+    }
+}
+
+impl<'input> Index<MarkedYaml<'input>> for String {
+    fn index_into<'y>(self, yaml: &'y MarkedYaml<'input>) -> Option<&'y MarkedYaml<'input>> {
+        self.as_str().index_into(yaml)
+    }
 }

--- a/saphyr/src/annotated/marked_yaml.rs
+++ b/saphyr/src/annotated/marked_yaml.rs
@@ -87,6 +87,10 @@ impl<'input> MarkedYaml<'input> {
         )
     }
 
+    /// Index into a YAML sequence or map.
+    /// A string index can be used to access a value in a map, and a usize index can be used to access an element of an sequence.
+    ///
+    /// Original implementation is from `serde_yaml` [get](https://docs.rs/serde_yaml/latest/serde_yaml/value/enum.Value.html#method.get)
     pub fn get<I: Index + 'static>(&self, index: I) -> Option<&Self> {
         index.index_into(self)
     }
@@ -102,16 +106,20 @@ impl Index for usize {
     }
 }
 
-impl Index for &'static str {
+impl Index for &str {
     fn index_into<'n, 'v>(self, v: &'v MarkedYaml<'n>) -> Option<&'v MarkedYaml<'n>> {
-        let key = MarkedYaml::value_from_str(self);
-        v.data
-            .as_mapping()
-            .and_then(move |elements| elements.get(&key))
+        self.to_string().index_into(v)
     }
 }
 
-impl<'a, I> Index for &'a I
+impl Index for String {
+    fn index_into<'n, 'v>(self, v: &'v MarkedYaml<'n>) -> Option<&'v MarkedYaml<'n>> {
+        let key = MarkedYaml::scalar_from_string(self);
+        v.data.as_mapping().and_then(|elements| elements.get(&key))
+    }
+}
+
+impl<I> Index for &I
 where
     I: Index + Clone,
 {

--- a/saphyr/src/annotated/marked_yaml.rs
+++ b/saphyr/src/annotated/marked_yaml.rs
@@ -86,6 +86,36 @@ impl<'input> MarkedYaml<'input> {
             },
         )
     }
+
+    pub fn get<I: Index>(&self, index: I) -> Option<&Self> {
+        index.index_into(self)
+    }
+}
+
+pub trait Index {
+    fn index_into<'v>(&self, v: &'v MarkedYaml) -> Option<&'v MarkedYaml>;
+}
+
+impl Index for usize {
+    fn index_into<'v>(&self, v: &'v MarkedYaml) -> Option<&'v MarkedYaml> {
+        v.data.as_vec().and_then(|elements| elements.get(*self))
+    }
+}
+
+impl Index for str {
+    fn index_into<'v>(&self, v: &'v MarkedYaml) -> Option<&'v MarkedYaml> {
+        let key = MarkedYaml::from_bare_yaml(Yaml::String(self.to_string()));
+        v.data.as_hash().and_then(|elements| elements.get(&key))
+    }
+}
+
+impl<'a, I> Index for &'a I
+where
+    I: ?Sized + Index,
+{
+    fn index_into<'v>(&self, v: &'v MarkedYaml) -> Option<&'v MarkedYaml> {
+        (**self).index_into(v)
+    }
 }
 
 impl super::AnnotatedNode for MarkedYaml<'_> {

--- a/saphyr/src/annotated/marked_yaml.rs
+++ b/saphyr/src/annotated/marked_yaml.rs
@@ -87,34 +87,37 @@ impl<'input> MarkedYaml<'input> {
         )
     }
 
-    pub fn get<I: Index>(&self, index: I) -> Option<&Self> {
+    pub fn get<I: Index + 'static>(&self, index: I) -> Option<&Self> {
         index.index_into(self)
     }
 }
 
 pub trait Index {
-    fn index_into<'v>(&self, v: &'v MarkedYaml) -> Option<&'v MarkedYaml>;
+    fn index_into<'n, 'v>(self, v: &'v MarkedYaml<'n>) -> Option<&'v MarkedYaml<'n>>;
 }
 
 impl Index for usize {
-    fn index_into<'v>(&self, v: &'v MarkedYaml) -> Option<&'v MarkedYaml> {
-        v.data.as_vec().and_then(|elements| elements.get(*self))
+    fn index_into<'n, 'v>(self, v: &'v MarkedYaml<'n>) -> Option<&'v MarkedYaml<'n>> {
+        v.data.as_vec().and_then(|elements| elements.get(self))
     }
 }
 
-impl Index for str {
-    fn index_into<'v>(&self, v: &'v MarkedYaml) -> Option<&'v MarkedYaml> {
-        let key = MarkedYaml::from_bare_yaml(Yaml::String(self.to_string()));
-        v.data.as_hash().and_then(|elements| elements.get(&key))
+impl Index for &'static str {
+    fn index_into<'n, 'v>(self, v: &'v MarkedYaml<'n>) -> Option<&'v MarkedYaml<'n>> {
+        let key = MarkedYaml::value_from_str(self);
+        v.data
+            .as_mapping()
+            .and_then(move |elements| elements.get(&key))
     }
 }
 
 impl<'a, I> Index for &'a I
 where
-    I: ?Sized + Index,
+    I: Index + Clone,
 {
-    fn index_into<'v>(&self, v: &'v MarkedYaml) -> Option<&'v MarkedYaml> {
-        (**self).index_into(v)
+    fn index_into<'v, 'n>(self, v: &'v MarkedYaml<'n>) -> Option<&'v MarkedYaml<'n>> {
+        let other = self.clone();
+        other.index_into(v)
     }
 }
 

--- a/saphyr/src/annotated/marked_yaml.rs
+++ b/saphyr/src/annotated/marked_yaml.rs
@@ -112,6 +112,44 @@ impl Index for &str {
     }
 }
 
+impl Index for MarkedYaml {
+    fn index_into<'v>(&self, v: &'v MarkedYaml) -> Option<&'v MarkedYaml> {
+        match &v.data {
+            YamlData::Array(vec) => {
+                if let Some(num) = self.data.as_i64() {
+                    vec.get(num as usize)
+                } else {
+                    None
+                }
+            }
+            YamlData::Hash(nodes) => nodes.get(self),
+            _ => None,
+        }
+    }
+}
+
+impl Index for YamlData<MarkedYaml> {
+    fn index_into<'v>(&self, v: &'v MarkedYaml) -> Option<&'v MarkedYaml> {
+        match &v.data {
+            YamlData::Array(vec) => {
+                if let Some(num) = self.as_i64() {
+                    vec.get(num as usize)
+                } else {
+                    None
+                }
+            }
+            YamlData::Hash(nodes) => {
+                let this = MarkedYaml {
+                    span: Span::default(),
+                    data: self.clone(),
+                };
+                nodes.get(&this)
+            }
+            _ => None,
+        }
+    }
+}
+
 impl Index for String {
     fn index_into<'n, 'v>(self, v: &'v MarkedYaml<'n>) -> Option<&'v MarkedYaml<'n>> {
         let key = MarkedYaml::scalar_from_string(self);

--- a/saphyr/src/annotated/marked_yaml_owned.rs
+++ b/saphyr/src/annotated/marked_yaml_owned.rs
@@ -9,6 +9,8 @@ use saphyr_parser::{ScalarStyle, Span, Tag};
 
 use crate::{LoadableYamlNode, ScalarOwned, Yaml, YamlDataOwned};
 
+use super::Indexable;
+
 /// A YAML node with [`Span`]s pointing to the start of the node.
 ///
 /// This structure does not implement functions to operate on the YAML object. To access those,
@@ -26,6 +28,12 @@ pub struct MarkedYamlOwned {
     pub span: Span,
     /// The YAML contents of the node.
     pub data: YamlDataOwned<MarkedYamlOwned>,
+}
+
+impl Indexable for MarkedYamlOwned {
+    fn get(&self, key: impl super::Index<Self>) -> Option<&Self> {
+        key.index_into(self)
+    }
 }
 
 impl MarkedYamlOwned {

--- a/saphyr/src/emitter.rs
+++ b/saphyr/src/emitter.rs
@@ -49,7 +49,8 @@ impl From<fmt::Error> for EmitError {
 ///
 /// assert_eq!(output, r#"---
 /// a: b
-/// c: d"#);
+/// c: d
+/// "#);
 /// ```
 #[allow(clippy::module_name_repetitions)]
 pub struct YamlEmitter<'a> {
@@ -222,7 +223,8 @@ impl<'a> YamlEmitter<'a> {
     /// foo: |-
     ///   bar!
     ///   bar!
-    /// baz: 42");
+    /// baz: 42
+    /// ");
     /// ```
     ///
     /// [literal style]: https://yaml.org/spec/1.2/spec.html#id2795688
@@ -244,7 +246,8 @@ impl<'a> YamlEmitter<'a> {
         writeln!(self.writer, "---")?;
         self.level = -1;
         let node = doc.node();
-        self.emit_node(&node)
+        self.emit_node(&node)?;
+        writeln!(self.writer).map_err(EmitError::FmtError)
     }
 
     fn write_indent(&mut self) -> EmitResult {

--- a/saphyr/src/lib.rs
+++ b/saphyr/src/lib.rs
@@ -141,7 +141,7 @@ mod yaml_owned;
 pub use crate::annotated::{
     marked_yaml::MarkedYaml, marked_yaml_owned::MarkedYamlOwned, AnnotatedMapping,
     AnnotatedMappingOwned, AnnotatedNode, AnnotatedNodeOwned, AnnotatedSequence,
-    AnnotatedSequenceOwned, AnnotatedYamlIter, YamlData, YamlDataOwned,
+    AnnotatedSequenceOwned, AnnotatedYamlIter, Index, Indexable, YamlData, YamlDataOwned,
 };
 pub use crate::emitter::{EmitError, YamlEmitter};
 pub use crate::loader::{LoadError, LoadableYamlNode, YamlLoader};

--- a/saphyr/tests/emitter.rs
+++ b/saphyr/tests/emitter.rs
@@ -138,7 +138,8 @@ products:
   "{}": empty hash key
 x: test
 y: avoid quoting here
-z: string with spaces"#;
+z: string with spaces
+"#;
 
     let docs = Yaml::load_from_str(s).unwrap();
     let doc = &docs[0];
@@ -196,7 +197,8 @@ null0: ~
   - "OFF"
 : false_bools
 bool0: true
-bool1: false"#;
+bool1: false
+"#;
 
     let docs = Yaml::load_from_str(input).unwrap();
     let doc = &docs[0];
@@ -232,7 +234,8 @@ a:
 e:
   - f
   - g
-  - h: []"
+  - h: []
+"
     } else {
         r"---
 a:
@@ -243,7 +246,8 @@ e:
   - f
   - g
   -
-    h: []"
+    h: []
+"
     };
 
     let docs = Yaml::load_from_str(s).unwrap();
@@ -266,7 +270,8 @@ a:
   - - c
     - d
     - - e
-      - f";
+      - f
+";
 
     let docs = Yaml::load_from_str(s).unwrap();
     let doc = &docs[0];
@@ -290,7 +295,8 @@ a:
     - d
     - - e
       - - f
-      - - e";
+      - - e
+";
 
     let docs = Yaml::load_from_str(s).unwrap();
     let doc = &docs[0];
@@ -312,7 +318,8 @@ a:
   b:
     c:
       d:
-        e: f";
+        e: f
+";
 
     let docs = Yaml::load_from_str(s).unwrap();
     let doc = &docs[0];

--- a/saphyr/tests/emitter.rs
+++ b/saphyr/tests/emitter.rs
@@ -1,4 +1,4 @@
-use saphyr::{LoadableYamlNode, Yaml, YamlEmitter};
+use saphyr::{LoadableYamlNode, MarkedYaml, Yaml, YamlEmitter};
 
 #[allow(clippy::similar_names)]
 #[test]
@@ -26,6 +26,40 @@ a4:
     println!("original:\n{s}");
     println!("emitted:\n{writer}");
     let docs_new = match Yaml::load_from_str(&writer) {
+        Ok(y) => y,
+        Err(e) => panic!("{}", e),
+    };
+    let doc_new = &docs_new[0];
+
+    assert_eq!(doc, doc_new);
+}
+
+#[allow(clippy::similar_names)]
+#[test]
+fn test_emit_simple_for_marked_yaml() {
+    let s = "
+# comment
+a0 bb: val
+a1:
+    b1: 4
+    b2: d
+a2: 4 # i'm comment
+a3: [1, 2, 3]
+a4:
+    - [a1, a2]
+    - 2
+";
+
+    let docs = MarkedYaml::load_from_str(s).unwrap();
+    let doc = &docs[0];
+    let mut writer = String::new();
+    {
+        let mut emitter = YamlEmitter::new(&mut writer);
+        emitter.dump(doc).unwrap();
+    }
+    println!("original:\n{s}");
+    println!("emitted:\n{writer}");
+    let docs_new = match MarkedYaml::load_from_str(&writer) {
         Ok(y) => y,
         Err(e) => panic!("{}", e),
     };


### PR DESCRIPTION
I have been porting a little tool I wrote to diff YAML at work from serde_yaml to saphyr in the hope to get really nice output by using MarkedYaml.

This goal of this draft PR is gauge interest in some of the API/surface changes that I needed.
I've tried to summarise a couple below

Index: serde_yaml has a [get(&self, index: I) -> Option<&Self>](https://docs.rs/serde_yaml/latest/serde_yaml/value/enum.Value.html#method.get) that is very handy to navigate code without panicing. While implementing Index as is done here allows foo["bar"] is compact, that fact that it panics means its less ideal for chains. Ideally all "variants" of YAML (i.e. Yaml and MarkedYaml) implement it.

Emittable: This I am less confident in. I needed to emit some of the MarkedYaml back to a string and as such I made a trait Emittable that is implemented to get nodes that can be emitted. For MarkedYaml this involves converting nodes from they AnnotatedX variant to just plain Yaml.

I will probably need a few more tweaks and changes that I will keep adding here.
If some of the seem right for their own PR, I'll gladly raise those separate PRs to get the changes upstreamed.

Update:

Added nicer spans for Hashes and Arrays that span the entire object.