### PR TITLE
parser: allow quoted scalars to be terminated without indentation

### DIFF
--- a/parser/src/scanner.rs
+++ b/parser/src/scanner.rs
@@ -1936,10 +1936,7 @@ impl<'input, T: Input> Scanner<'input, T> {
             }
 
             if (self.mark.col as isize) < self.indent {
-                return Err(ScanError::new_str(
-                    start_mark,
-                    "invalid indentation in quoted scalar",
-                ));
+                break;
             }
 
             leading_blanks = false;

--- a/parser/tests/basic.rs
+++ b/parser/tests/basic.rs
@@ -353,6 +353,45 @@ hash:
 }
 
 #[test]
+fn test_quoted_string_indentation() {
+    let table = run_parser(
+        r"
+hash:
+    string: 'Closing single quote is
+        present but
+        not indented.
+  '
+    after: value
+",
+    )
+    .unwrap();
+
+    assert_eq!(
+        table,
+        [
+            Event::StreamStart,
+            Event::DocumentStart(false),
+            Event::MappingStart(0, None),
+            Event::Scalar("hash".into(), ScalarStyle::Plain, 0, None),
+            Event::MappingStart(0, None),
+            Event::Scalar("string".into(), ScalarStyle::Plain, 0, None),
+            Event::Scalar(
+                "Closing single quote is present but not indented. ".into(),
+                ScalarStyle::SingleQuoted,
+                0,
+                None
+            ),
+            Event::Scalar("after".into(), ScalarStyle::Plain, 0, None),
+            Event::Scalar("value".into(), ScalarStyle::Plain, 0, None),
+            Event::MappingEnd,
+            Event::MappingEnd,
+            Event::DocumentEnd,
+            Event::StreamEnd,
+        ]
+    );
+}
+
+#[test]
 fn test_recursion_depth_check_objects() {
     let s = "{a:".repeat(10_000) + &"}".repeat(10_000);
     assert!(run_parser(&s).is_err());


### PR DESCRIPTION
If a quoted scalar ends before its expected column then we should terminate the quoted string value rather than emitting an error.

Closes: #57