### PR TITLE
Parse True and TRUE as bools

### DIFF
--- a/saphyr/src/scalar.rs
+++ b/saphyr/src/scalar.rs
@@ -188,9 +188,9 @@ impl<'input> Scalar<'input> {
             }
         }
         match &*v {
-            "~" | "null" | "NULL" => Self::Null,
-            "true" => Self::Boolean(true),
-            "false" => Self::Boolean(false),
+            "~" | "null" | "Null" | "NULL" => Self::Null,
+            "true" | "True" | "TRUE" => Self::Boolean(true),
+            "false" | "False" | "FALSE" => Self::Boolean(false),
             _ => {
                 if let Ok(integer) = v.parse::<i64>() {
                     Self::Integer(integer)

--- a/saphyr/tests/emitter.rs
+++ b/saphyr/tests/emitter.rs
@@ -126,8 +126,8 @@ string2: "true"
 string3: "false"
 string4: "~"
 null0: ~
-[true, false]: real_bools
-[True, TRUE, False, FALSE, y,Y,yes,Yes,YES,n,N,no,No,NO,on,On,ON,off,Off,OFF]: false_bools
+[true, True, TRUE, false, False, FALSE]: real_bools
+[y,Y,yes,Yes,YES,n,N,no,No,NO,on,On,ON,off,Off,OFF]: false_bools
 bool0: true
 bool1: false"#;
     let expected = r#"---
@@ -138,13 +138,13 @@ string3: "false"
 string4: "~"
 null0: ~
 ? - true
+  - true
+  - true
+  - false
+  - false
   - false
 : real_bools
-? - "True"
-  - "TRUE"
-  - "False"
-  - "FALSE"
-  - y
+? - y
   - Y
   - "yes"
   - "Yes"


### PR DESCRIPTION
Currently, `saphyr` parses the plain scalar `True` as a string. But according to the [core schema](https://yaml.org/spec/1.2.2/#core-schema) these should be parsed as booleans. Since `saphyr` interprets most other things (e.g. `.NaN`) according to the core schema, I think it should do the same for booleans.