### PR TITLE
Add `no_std` support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - run: rustup toolchain install stable --profile minimal --component rustfmt --component clippy --no-self-update
+      - run: rustup target add wasm32v1-none
       - uses: Swatinem/rust-cache@v2
       - name: Run clippy checks
         run: cargo clippy --all-targets -- -D warnings
       - name: Run format checks
         run: cargo fmt --check
+      - name: Check `no_std` compatibility
+        run: cargo check --no-default-features --target wasm32v1-none
 
   test:
     name: Test using Rust ${{ matrix.rust }} on ${{ matrix.os }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -725,6 +725,7 @@ dependencies = [
  "ordered-float",
  "quickcheck",
  "saphyr-parser",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -748,6 +749,7 @@ name = "saphyr-parser"
 version = "0.0.6"
 dependencies = [
  "arraydeque",
+ "hashbrown",
  "hashlink",
  "libtest-mimic",
  "miette",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,8 +31,10 @@ edition = "2021"
 rust-version = "1.65.0"
 
 [workspace.dependencies]
-arraydeque = "0.5.1"
+arraydeque = { version = "0.5.1", default-features = false }
 encoding_rs = { version = "0.8.33" }
+# Keep in sync with hashlink to reduce dependency duplication
+hashbrown = { version = "0.15", default-features = false, features = ["default-hasher"] }
 hashlink = "0.10"
 libtest-mimic = "0.8.1"
 miette = { version = "7.5.0", features = ["fancy"] }
@@ -42,7 +44,7 @@ rustyline = "16.0.0"
 saphyr = { path = "saphyr" }
 saphyr-bench = { path = "bench" }
 saphyr-parser = { path = "parser" }
-thiserror = "2.0.12"
+thiserror = { version = "2.0.12", default-features = false }
 
 [workspace.lints.rust]
 unsafe_op_in_unsafe_fn = "deny"

--- a/parser/Cargo.toml
+++ b/parser/Cargo.toml
@@ -25,6 +25,8 @@ debug_prints = []
 [dependencies]
 arraydeque = { workspace = true }
 hashlink = { workspace = true }
+hashbrown = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 libtest-mimic = { workspace = true }
@@ -32,7 +34,6 @@ miette = { workspace = true }
 quickcheck = { workspace = true }
 rustyline = { workspace = true }
 saphyr = { workspace = true }
-thiserror = { workspace = true }
 
 [[test]]
 name = "yaml-test-suite"

--- a/parser/src/input.rs
+++ b/parser/src/input.rs
@@ -3,6 +3,8 @@
 //! [`Input`] must be implemented for the parser to fetch input. Make sure your needs aren't
 //! covered by the [`BufferedInput`].
 
+use alloc::string::String;
+
 pub(crate) mod buffered;
 pub(crate) mod str;
 

--- a/parser/src/input/str.rs
+++ b/parser/src/input/str.rs
@@ -4,6 +4,7 @@ use crate::{
     },
     input::{Input, SkipTabs},
 };
+use alloc::string::String;
 
 /// A parser input that uses a `&str` as source.
 #[allow(clippy::module_name_repetitions)]

--- a/parser/src/lib.rs
+++ b/parser/src/lib.rs
@@ -28,8 +28,17 @@
 //! decrease performance.
 //!
 //! The MSRV for this feature is `1.70.0`.
+//! 
+//! This feature is _not_ `no_std` compatible.
 
 #![warn(missing_docs, clippy::pedantic)]
+#![no_std]
+
+#[macro_use]
+extern crate alloc;
+
+#[cfg(feature = "debug_prints")]
+extern crate std;
 
 mod char_traits;
 #[macro_use]

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -10,7 +10,14 @@ use crate::{
     BufferedInput, Marker,
 };
 
-use std::{borrow::Cow, collections::HashMap, fmt::Display};
+use alloc::{
+    borrow::Cow,
+    string::{String, ToString},
+    vec::Vec,
+};
+use core::fmt::Display;
+
+use hashbrown::HashMap;
 
 #[derive(Clone, Copy, PartialEq, Debug, Eq)]
 enum State {
@@ -117,7 +124,7 @@ impl Tag {
 }
 
 impl Display for Tag {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         if self.handle == "!" {
             write!(f, "!{}", self.suffix)
         } else {
@@ -539,6 +546,7 @@ impl<'input, T: Input> Parser<'input, T> {
                 self.load_mapping(recv)
             }
             _ => {
+                #[cfg(feature = "debug_prints")]
                 println!("UNREACHABLE EVENT: {first_ev:?}");
                 unreachable!();
             }

--- a/parser/src/scanner.rs
+++ b/parser/src/scanner.rs
@@ -9,7 +9,15 @@
 #![allow(clippy::cast_possible_wrap)]
 #![allow(clippy::cast_sign_loss)]
 
-use std::{borrow::Cow, char, collections::VecDeque, error::Error, fmt};
+use alloc::{
+    borrow::{Cow, ToOwned},
+    collections::VecDeque,
+    string::String,
+    vec::Vec,
+};
+use core::char;
+
+use thiserror::Error;
 
 use crate::{
     char_traits::{
@@ -132,7 +140,8 @@ impl Span {
 }
 
 /// An error that occurred while scanning.
-#[derive(Clone, PartialEq, Debug, Eq)]
+#[derive(Clone, PartialEq, Debug, Eq, Error)]
+#[error("{} at byte {} line {} column {}", .info, .mark.index, .mark.line, .mark.col + 1,)]
 pub struct ScanError {
     /// The position at which the error happened in the source.
     mark: Marker,
@@ -166,25 +175,6 @@ impl ScanError {
     #[must_use]
     pub fn info(&self) -> &str {
         self.info.as_ref()
-    }
-}
-
-impl Error for ScanError {
-    fn source(&self) -> Option<&(dyn Error + 'static)> {
-        None
-    }
-}
-
-impl fmt::Display for ScanError {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        write!(
-            formatter,
-            "{} at byte {} line {} column {}",
-            self.info,
-            self.mark.index,
-            self.mark.line,
-            self.mark.col + 1,
-        )
     }
 }
 

--- a/saphyr/Cargo.toml
+++ b/saphyr/Cargo.toml
@@ -26,6 +26,7 @@ encoding_rs = { workspace = true, optional = true }
 hashlink = { workspace = true }
 ordered-float = { workspace = true }
 saphyr-parser = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 quickcheck = { workspace = true }

--- a/saphyr/src/annotated.rs
+++ b/saphyr/src/annotated.rs
@@ -38,7 +38,7 @@
 //! In order to add a new Node type, the following is required:
 //!   - Use either [`YamlData`] or [`YamlDataOwned`]. There shouldn't be a need for any other Data
 //!     type.
-//!   - Implement [`std::hash::Hash`], [`std::cmp::Eq`] and [`std::cmp::PartialEq`] for your Node
+//!   - Implement [`core::hash::Hash`], [`core::cmp::Eq`] and [`core::cmp::PartialEq`] for your Node
 //!     type. These traits are required for [`AnnotatedNode`].
 //!   - Implement [`AnnotatedNode`] or [`AnnotatedNodeOwned`] for your Node type, depending on
 //!     whether it is borrowed or not.
@@ -69,10 +69,10 @@ pub use yaml_data_owned::{AnnotatedMappingOwned, AnnotatedSequenceOwned, YamlDat
 ///
 /// [`LoadableYamlNode::HashKey`]: crate::loader::LoadableYamlNode::HashKey
 #[allow(clippy::module_name_repetitions)]
-pub trait AnnotatedNode: std::hash::Hash + std::cmp::Eq {
+pub trait AnnotatedNode: core::hash::Hash + core::cmp::Eq {
     /// The type used as the key in the [`YamlData::Mapping`] variant.
     type HashKey<'a>: From<YamlData<'a, Self::HashKey<'a>>>
-        + for<'b> std::cmp::PartialEq<Self::HashKey<'b>>
+        + for<'b> core::cmp::PartialEq<Self::HashKey<'b>>
         + AnnotatedNode;
 
     /// See [`YamlData::parse_representation_recursive`].
@@ -87,10 +87,10 @@ pub trait AnnotatedNode: std::hash::Hash + std::cmp::Eq {
 ///
 /// [`LoadableYamlNode::HashKey`]: crate::loader::LoadableYamlNode::HashKey
 #[allow(clippy::module_name_repetitions)]
-pub trait AnnotatedNodeOwned: std::hash::Hash + std::cmp::Eq {
+pub trait AnnotatedNodeOwned: core::hash::Hash + core::cmp::Eq {
     /// The type used as the key in the [`YamlDataOwned::Mapping`] variant.
     type HashKey: From<YamlDataOwned<Self::HashKey>>
-        + std::cmp::PartialEq<Self::HashKey>
+        + core::cmp::PartialEq<Self::HashKey>
         + AnnotatedNodeOwned;
 
     /// See [`YamlData::parse_representation_recursive`].

--- a/saphyr/src/annotated/marked_yaml.rs
+++ b/saphyr/src/annotated/marked_yaml.rs
@@ -2,7 +2,7 @@
 //!
 //! This is set aside so as to not clutter `annotated.rs`.
 
-use std::borrow::Cow;
+use alloc::{borrow::Cow, boxed::Box, string::String, vec::Vec};
 
 use hashlink::LinkedHashMap;
 use saphyr_parser::{Marker, ScalarStyle, Span, Tag};
@@ -116,8 +116,8 @@ impl<'b> PartialEq<MarkedYaml<'b>> for MarkedYaml<'_> {
 // I don't know if it's okay to implement that, but we need it for the hashmap.
 impl Eq for MarkedYaml<'_> {}
 
-impl std::hash::Hash for MarkedYaml<'_> {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+impl core::hash::Hash for MarkedYaml<'_> {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
         self.data.hash(state);
     }
 }
@@ -197,7 +197,7 @@ impl<'input> LoadableYamlNode<'input> for MarkedYaml<'input> {
             span: Span::default(),
             data: YamlData::BadValue,
         };
-        std::mem::swap(&mut taken_out, self);
+        core::mem::swap(&mut taken_out, self);
         taken_out
     }
 

--- a/saphyr/src/annotated/marked_yaml_owned.rs
+++ b/saphyr/src/annotated/marked_yaml_owned.rs
@@ -2,7 +2,12 @@
 //!
 //! This is set aside so as to not clutter `annotated.rs`.
 
-use std::borrow::Cow;
+use alloc::{
+    borrow::Cow,
+    boxed::Box,
+    string::{String, ToString},
+    vec::Vec,
+};
 
 use hashlink::LinkedHashMap;
 use saphyr_parser::{ScalarStyle, Span, Tag};
@@ -123,8 +128,8 @@ impl PartialEq<MarkedYamlOwned> for MarkedYamlOwned {
 // I don't know if it's okay to implement that, but we need it for the hashmap.
 impl Eq for MarkedYamlOwned {}
 
-impl std::hash::Hash for MarkedYamlOwned {
-    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+impl core::hash::Hash for MarkedYamlOwned {
+    fn hash<H: core::hash::Hasher>(&self, state: &mut H) {
         self.data.hash(state);
     }
 }
@@ -206,7 +211,7 @@ impl LoadableYamlNode<'_> for MarkedYamlOwned {
             span: Span::default(),
             data: YamlDataOwned::BadValue,
         };
-        std::mem::swap(&mut taken_out, self);
+        core::mem::swap(&mut taken_out, self);
         taken_out
     }
 

--- a/saphyr/src/annotated/yaml_data.rs
+++ b/saphyr/src/annotated/yaml_data.rs
@@ -1,5 +1,5 @@
-use std::{
-    borrow::Cow,
+use alloc::{borrow::Cow, boxed::Box, vec::Vec};
+use core::{
     hash::{BuildHasher, Hasher},
     marker::PhantomData,
     ops::{Index, IndexMut},
@@ -40,7 +40,7 @@ use crate::{annotated::AnnotatedNode, Scalar};
 #[derive(Clone, PartialEq, PartialOrd, Debug, Eq, Ord, Hash)]
 pub enum YamlData<'input, Node>
 where
-    Node: std::hash::Hash + std::cmp::Eq + From<Self> + AnnotatedNode,
+    Node: core::hash::Hash + core::cmp::Eq + From<Self> + AnnotatedNode,
 {
     /// The raw string from the input.
     ///
@@ -120,11 +120,11 @@ define_yaml_object_impl!(
     YamlData<'input, Node>,
     < 'input, Node>,
     where {
-        Node: std::hash::Hash
-            + std::cmp::Eq
+        Node: core::hash::Hash
+            + core::cmp::Eq
             + From<Self>
             + AnnotatedNode
-            + for<'a> std::cmp::PartialEq<Node::HashKey<'a>>,
+            + for<'a> core::cmp::PartialEq<Node::HashKey<'a>>,
     },
     mappingtype = AnnotatedMapping<'input, Node>,
     sequencetype = AnnotatedSequence<Node>,
@@ -136,17 +136,17 @@ define_yaml_object_impl!(
 
 impl<'input, Node> YamlData<'input, Node>
 where
-    Node: std::hash::Hash
-        + std::cmp::Eq
+    Node: core::hash::Hash
+        + core::cmp::Eq
         + From<Self>
         + AnnotatedNode
-        + for<'a> std::cmp::PartialEq<Node::HashKey<'a>>,
+        + for<'a> core::cmp::PartialEq<Node::HashKey<'a>>,
 {
     /// Take the contained node out of `Self`, leaving a `BadValue` in its place.
     #[must_use]
     pub fn take(&mut self) -> Self {
         let mut taken_out = Self::BadValue;
-        std::mem::swap(self, &mut taken_out);
+        core::mem::swap(self, &mut taken_out);
         taken_out
     }
 
@@ -155,7 +155,7 @@ where
     where
         'input: 'a,
     {
-        use std::hash::Hash;
+        use core::hash::Hash;
 
         match self {
             Self::Mapping(mapping) => {
@@ -182,8 +182,8 @@ where
     fn as_mapping_get_mut_impl(&mut self, key: &str) -> Option<&mut Node> {
         match self.as_mapping_mut() {
             Some(mapping) => {
+                use core::hash::Hash;
                 use hashlink::linked_hash_map::RawEntryMut::{Occupied, Vacant};
-                use std::hash::Hash;
 
                 // In order to work around `needle`'s lifetime being different from `h`'s, we need
                 // to manually compute the hash. Otherwise, we'd use `h.get()`, which complains the
@@ -208,11 +208,11 @@ where
 
 impl<'input, Node> IntoIterator for YamlData<'input, Node>
 where
-    Node: std::hash::Hash
-        + std::cmp::Eq
+    Node: core::hash::Hash
+        + core::cmp::Eq
         + From<Self>
         + AnnotatedNode
-        + for<'a> std::cmp::PartialEq<Node::HashKey<'a>>,
+        + for<'a> core::cmp::PartialEq<Node::HashKey<'a>>,
 {
     type Item = Node;
     type IntoIter = AnnotatedYamlIter<'input, Node>;
@@ -229,15 +229,15 @@ where
 #[allow(clippy::module_name_repetitions)]
 pub struct AnnotatedYamlIter<'input, Node>
 where
-    Node: std::hash::Hash + std::cmp::Eq + From<YamlData<'input, Node>> + AnnotatedNode,
+    Node: core::hash::Hash + core::cmp::Eq + From<YamlData<'input, Node>> + AnnotatedNode,
 {
-    yaml: std::vec::IntoIter<Node>,
+    yaml: alloc::vec::IntoIter<Node>,
     marker: PhantomData<&'input ()>,
 }
 
 impl<'input, Node> Iterator for AnnotatedYamlIter<'input, Node>
 where
-    Node: std::hash::Hash + std::cmp::Eq + From<YamlData<'input, Node>> + AnnotatedNode,
+    Node: core::hash::Hash + core::cmp::Eq + From<YamlData<'input, Node>> + AnnotatedNode,
 {
     type Item = Node;
 

--- a/saphyr/src/annotated/yaml_data_owned.rs
+++ b/saphyr/src/annotated/yaml_data_owned.rs
@@ -1,4 +1,9 @@
-use std::{
+use alloc::{
+    boxed::Box,
+    string::{String, ToString},
+    vec::Vec,
+};
+use core::{
     hash::{BuildHasher, Hasher},
     ops::{Index, IndexMut},
 };
@@ -16,7 +21,7 @@ use crate::{annotated::AnnotatedNodeOwned, ScalarOwned};
 #[derive(Clone, PartialEq, PartialOrd, Debug, Eq, Ord, Hash)]
 pub enum YamlDataOwned<Node>
 where
-    Node: std::hash::Hash + std::cmp::Eq + From<Self> + AnnotatedNodeOwned,
+    Node: core::hash::Hash + core::cmp::Eq + From<Self> + AnnotatedNodeOwned,
 {
     /// The raw string from the input.
     ///
@@ -67,11 +72,11 @@ define_yaml_object_impl!(
     YamlDataOwned<Node>,
     < Node>,
     where {
-        Node: std::hash::Hash
-            + std::cmp::Eq
+        Node: core::hash::Hash
+            + core::cmp::Eq
             + From<Self>
             + AnnotatedNodeOwned
-            + std::cmp::PartialEq<Node::HashKey>,
+            + core::cmp::PartialEq<Node::HashKey>,
     },
     mappingtype = AnnotatedMappingOwned<Node>,
     sequencetype = AnnotatedSequenceOwned<Node>,
@@ -83,23 +88,23 @@ define_yaml_object_impl!(
 
 impl<Node> YamlDataOwned<Node>
 where
-    Node: std::hash::Hash
-        + std::cmp::Eq
+    Node: core::hash::Hash
+        + core::cmp::Eq
         + From<Self>
         + AnnotatedNodeOwned
-        + std::cmp::PartialEq<Node::HashKey>,
+        + core::cmp::PartialEq<Node::HashKey>,
 {
     /// Take the contained node out of `Self`, leaving a `BadValue` in its place.
     #[must_use]
     pub fn take(&mut self) -> Self {
         let mut taken_out = Self::BadValue;
-        std::mem::swap(self, &mut taken_out);
+        core::mem::swap(self, &mut taken_out);
         taken_out
     }
 
     /// Implementation detail for [`Self::as_mapping_get`], which is generated from a macro.
     fn as_mapping_get_impl(&self, key: &str) -> Option<&Node> {
-        use std::hash::Hash;
+        use core::hash::Hash;
 
         match self {
             Self::Mapping(mapping) => {
@@ -127,8 +132,8 @@ where
     fn as_mapping_get_mut_impl(&mut self, key: &str) -> Option<&mut Node> {
         match self.as_mapping_mut() {
             Some(mapping) => {
+                use core::hash::Hash;
                 use hashlink::linked_hash_map::RawEntryMut::{Occupied, Vacant};
-                use std::hash::Hash;
 
                 // In order to work around `needle`'s lifetime being different from `h`'s, we need
                 // to manually compute the hash. Otherwise, we'd use `h.get()`, which complains the
@@ -154,11 +159,11 @@ where
 
 impl<Node> IntoIterator for YamlDataOwned<Node>
 where
-    Node: std::hash::Hash
-        + std::cmp::Eq
+    Node: core::hash::Hash
+        + core::cmp::Eq
         + From<Self>
         + AnnotatedNodeOwned
-        + std::cmp::PartialEq<Node::HashKey>,
+        + core::cmp::PartialEq<Node::HashKey>,
 {
     type Item = Node;
     type IntoIter = AnnotatedYamlOwnedIter<Node>;
@@ -174,14 +179,14 @@ where
 #[allow(clippy::module_name_repetitions)]
 pub struct AnnotatedYamlOwnedIter<Node>
 where
-    Node: std::hash::Hash + std::cmp::Eq + From<YamlDataOwned<Node>> + AnnotatedNodeOwned,
+    Node: core::hash::Hash + core::cmp::Eq + From<YamlDataOwned<Node>> + AnnotatedNodeOwned,
 {
-    yaml: std::vec::IntoIter<Node>,
+    yaml: alloc::vec::IntoIter<Node>,
 }
 
 impl<Node> Iterator for AnnotatedYamlOwnedIter<Node>
 where
-    Node: std::hash::Hash + std::cmp::Eq + From<YamlDataOwned<Node>> + AnnotatedNodeOwned,
+    Node: core::hash::Hash + core::cmp::Eq + From<YamlDataOwned<Node>> + AnnotatedNodeOwned,
 {
     type Item = Node;
 

--- a/saphyr/src/emitter.rs
+++ b/saphyr/src/emitter.rs
@@ -1,39 +1,21 @@
 //! YAML serialization helpers.
 
+use core::fmt;
+
+use thiserror::Error;
+
 use crate::{
     char_traits,
     yaml::{Mapping, Yaml},
     Scalar,
 };
-use std::convert::From;
-use std::error::Error;
-use std::fmt::{self, Display};
 
 /// An error when emitting YAML.
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Error)]
 pub enum EmitError {
     /// A formatting error.
-    FmtError(fmt::Error),
-}
-
-impl Error for EmitError {
-    fn cause(&self) -> Option<&dyn Error> {
-        None
-    }
-}
-
-impl Display for EmitError {
-    fn fmt(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            EmitError::FmtError(ref err) => Display::fmt(err, formatter),
-        }
-    }
-}
-
-impl From<fmt::Error> for EmitError {
-    fn from(f: fmt::Error) -> Self {
-        EmitError::FmtError(f)
-    }
+    #[error("{0}")]
+    FmtError(#[from] fmt::Error),
 }
 
 /// The YAML serializer.
@@ -466,6 +448,8 @@ fn need_quotes(string: &str) -> bool {
 
 #[cfg(test)]
 mod test {
+    use alloc::string::String;
+
     use crate::{LoadableYamlNode, Yaml, YamlEmitter};
 
     #[test]

--- a/saphyr/src/encoding.rs
+++ b/saphyr/src/encoding.rs
@@ -1,6 +1,7 @@
 //! Encoding utilities. Available only with the `encoding` feature.
 
-use std::{borrow::Cow, ops::ControlFlow};
+use alloc::{borrow::Cow, string::String, vec::Vec};
+use core::ops::ControlFlow;
 
 use encoding_rs::{Decoder, DecoderResult, Encoding};
 
@@ -231,7 +232,7 @@ c: [1, 2]
         let mut decoder = YamlDecoder::read(s as &[u8]);
         let out = decoder.decode().unwrap();
         let doc = &out[0];
-        println!("GOT: {doc:?}");
+        std::println!("GOT: {doc:?}");
         assert_eq!(doc["a"].as_integer().unwrap(), 1i64);
         assert!((doc["b"].as_floating_point().unwrap() - 2.2f64) <= f64::EPSILON);
         assert_eq!(doc["c"][1].as_integer().unwrap(), 2i64);
@@ -248,7 +249,7 @@ c: [1, 2]
         let mut decoder = YamlDecoder::read(s as &[u8]);
         let out = decoder.decode().unwrap();
         let doc = &out[0];
-        println!("GOT: {doc:?}");
+        std::println!("GOT: {doc:?}");
         assert_eq!(doc["a"].as_integer().unwrap(), 1i64);
         assert!((doc["b"].as_floating_point().unwrap() - 2.2f64).abs() <= f64::EPSILON);
         assert_eq!(doc["c"][1].as_integer().unwrap(), 2i64);
@@ -265,7 +266,7 @@ c: [1, 2]
         let mut decoder = YamlDecoder::read(s as &[u8]);
         let out = decoder.decode().unwrap();
         let doc = &out[0];
-        println!("GOT: {doc:?}");
+        std::println!("GOT: {doc:?}");
         assert_eq!(doc["a"].as_integer().unwrap(), 1i64);
         assert!((doc["b"].as_floating_point().unwrap() - 2.2f64).abs() <= f64::EPSILON);
         assert_eq!(doc["c"][1].as_integer().unwrap(), 2i64);
@@ -285,7 +286,7 @@ c: [1, 2]
             .decode()
             .unwrap();
         let doc = &out[0];
-        println!("GOT: {doc:?}");
+        std::println!("GOT: {doc:?}");
         assert_eq!(doc["a"].as_integer().unwrap(), 1i64);
         assert!((doc["b"].as_floating_point().unwrap() - 2.2f64).abs() <= f64::EPSILON);
         assert_eq!(doc["c"][1].as_integer().unwrap(), 2i64);

--- a/saphyr/src/index.rs
+++ b/saphyr/src/index.rs
@@ -1,3 +1,5 @@
+use alloc::string::{String, ToString};
+
 /// A trait to index without panicking into a structure through an [`Accessor`].
 ///
 /// [`SafelyIndex`] is implemented on YAML objects to provide the [`get`] method to conveniently
@@ -6,7 +8,7 @@
 /// out of range.
 ///
 /// [`get`]: SafelyIndex::get
-/// [`Index`]: std::ops::Index
+/// [`Index`]: core::ops::Index
 pub trait SafelyIndex<Node = Self> {
     /// Access a field of the given YAML object.
     ///
@@ -25,7 +27,7 @@ pub trait SafelyIndex<Node = Self> {
 /// the requested index is out of range.
 ///
 /// [`get_mut`]: SafelyIndexMut::get_mut
-/// [`IndexMut`]: std::ops::Index
+/// [`IndexMut`]: core::ops::Index
 pub trait SafelyIndexMut<Node = Self> {
     /// Access a field of the given YAML object (mutable).
     ///

--- a/saphyr/src/lib.rs
+++ b/saphyr/src/lib.rs
@@ -114,6 +114,8 @@
 //!
 //! The MSRV for this feature is `1.70.0`.
 //!
+//! This feature is _not_ `no_std` compatible.
+//!
 //! [`MarkedYaml`]: crate::MarkedYaml
 //! [`MarkedYamlOwned`]: crate::MarkedYamlOwned
 //! [`Marker`]: crate::Marker
@@ -125,6 +127,12 @@
 //! [`early_parse`]: crate::YamlLoader::early_parse
 
 #![warn(missing_docs, clippy::pedantic)]
+#![no_std]
+
+#[macro_use]
+extern crate alloc;
+#[cfg(any(feature = "encoding", test))]
+extern crate std;
 
 #[macro_use]
 mod macros;

--- a/saphyr/src/loader.rs
+++ b/saphyr/src/loader.rs
@@ -1,13 +1,18 @@
 //! The default loader.
 
-use std::{borrow::Cow, collections::BTreeMap, marker::PhantomData, sync::Arc};
+use alloc::{borrow::Cow, collections::BTreeMap, vec::Vec};
+use core::marker::PhantomData;
 
 use hashlink::LinkedHashMap;
 use saphyr_parser::{
     BufferedInput, Event, Input, Marker, Parser, ScanError, Span, SpannedEventReceiver, Tag,
 };
+use thiserror::Error;
 
 use crate::{Mapping, Yaml};
+
+#[cfg(feature = "encoding")]
+use alloc::sync::Arc;
 
 /// Main structure for parsing YAML.
 ///
@@ -37,7 +42,7 @@ where
 ///
 /// This trait must be implemented on YAML node types (i.e.: [`Yaml`] and annotated YAML nodes). It
 /// provides the necessary methods for [`YamlLoader`] to load data into the node.
-pub trait LoadableYamlNode<'input>: Clone + std::hash::Hash + Eq {
+pub trait LoadableYamlNode<'input>: Clone + core::hash::Hash + Eq {
     /// The type of the key for the hash variant of the YAML node.
     ///
     /// The `HashKey` must be [`Eq`] and [`Hash`] to satisfy the hash map requirements.
@@ -53,12 +58,12 @@ pub trait LoadableYamlNode<'input>: Clone + std::hash::Hash + Eq {
     /// [here](https://github.com/rust-lang/rust/issues/124614#issuecomment-2090725842). A previous
     /// attempt at solving lifetimes used capsules, but [`AnnotatedNode`] is sufficient.
     ///
-    /// [`Hash`]: std::hash::Hash
-    /// [`Borrow<Self>`]: std::borrow::Borrow
+    /// [`Hash`]: core::hash::Hash
+    /// [`Borrow<Self>`]: core::borrow::Borrow
     /// [`From<Self>`]: From
     /// [`PartialEq<Self>`]: PartialEq
     /// [`AnnotatedNode`]: crate::annotated::AnnotatedNode
-    type HashKey: Eq + std::hash::Hash + std::borrow::Borrow<Self> + From<Self>;
+    type HashKey: Eq + core::hash::Hash + core::borrow::Borrow<Self> + From<Self>;
 
     /// Create an instance of `Self` from a [`Yaml`].
     ///
@@ -354,38 +359,24 @@ where
 }
 
 /// An error that happened when loading a YAML document.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Error)]
+#[non_exhaustive]
 pub enum LoadError {
     /// An I/O error.
-    IO(Arc<std::io::Error>),
+    #[cfg(feature = "encoding")]
+    #[error("{0}")]
+    IO(#[source] Arc<std::io::Error>),
     /// An error within the scanner. This indicates a malformed YAML input.
-    Scan(ScanError),
+    #[error("{0}")]
+    Scan(#[source] ScanError),
     /// A decoding error (e.g.: Invalid UTF-8).
-    Decode(std::borrow::Cow<'static, str>),
+    #[error("{0}")]
+    Decode(alloc::borrow::Cow<'static, str>),
 }
 
+#[cfg(feature = "encoding")]
 impl From<std::io::Error> for LoadError {
     fn from(error: std::io::Error) -> Self {
         LoadError::IO(Arc::new(error))
-    }
-}
-
-impl std::error::Error for LoadError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
-        Some(match &self {
-            LoadError::IO(e) => e,
-            LoadError::Scan(e) => e,
-            LoadError::Decode(_) => return None,
-        })
-    }
-}
-
-impl std::fmt::Display for LoadError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            LoadError::IO(e) => e.fmt(f),
-            LoadError::Scan(e) => e.fmt(f),
-            LoadError::Decode(e) => e.fmt(f),
-        }
     }
 }

--- a/saphyr/src/scalar.rs
+++ b/saphyr/src/scalar.rs
@@ -1,6 +1,6 @@
 //! Wrapper around a [YAML scalar](https://yaml.org/spec/1.2.2/#23-scalars).
 
-use std::borrow::Cow;
+use alloc::{borrow::Cow, string::String};
 
 use ordered_float::OrderedFloat;
 use saphyr_parser::{ScalarStyle, Tag};
@@ -74,8 +74,9 @@ impl<'input> Scalar<'input> {
     ///
     /// # Examples
     /// ```
+    /// # extern crate alloc;
     /// # use saphyr::{Scalar, ScalarStyle, Tag};
-    /// use std::borrow::Cow::Owned;
+    /// use alloc::borrow::Cow::Owned;
     /// let yaml_handle = "tag:yaml.org,2002:".to_string();
     /// assert_eq!(
     ///     Scalar::parse_from_cow_and_metadata("123".into(), ScalarStyle::Plain, None),

--- a/saphyr/src/yaml.rs
+++ b/saphyr/src/yaml.rs
@@ -2,8 +2,8 @@
 
 #![allow(clippy::module_name_repetitions)]
 
-use std::{
-    borrow::Cow,
+use alloc::{borrow::Cow, boxed::Box, vec::Vec};
+use core::{
     convert::TryFrom,
     hash::{BuildHasher, Hasher},
     ops::{Index, IndexMut},
@@ -193,7 +193,7 @@ impl<'input> LoadableYamlNode<'input> for Yaml<'input> {
 
     fn take(&mut self) -> Self {
         let mut taken_out = Yaml::BadValue;
-        std::mem::swap(&mut taken_out, self);
+        core::mem::swap(&mut taken_out, self);
         taken_out
     }
 }
@@ -211,7 +211,7 @@ impl<'input> IntoIterator for Yaml<'input> {
 
 /// An iterator over a [`Yaml`] node.
 pub struct YamlIter<'input> {
-    yaml: std::vec::IntoIter<Yaml<'input>>,
+    yaml: alloc::vec::IntoIter<Yaml<'input>>,
 }
 
 impl<'input> Iterator for YamlIter<'input> {
@@ -224,7 +224,7 @@ impl<'input> Iterator for YamlIter<'input> {
 
 /// Hash the given `str` as if it were a [`Scalar::String`] object.
 fn hash_str_as_yaml_string<H: Hasher>(key: &str, mut hasher: H) -> u64 {
-    use std::hash::Hash;
+    use core::hash::Hash;
     let key = Yaml::Value(Scalar::String(key.into()));
     key.hash(&mut hasher);
     hasher.finish()

--- a/saphyr/src/yaml_owned.rs
+++ b/saphyr/src/yaml_owned.rs
@@ -2,8 +2,8 @@
 
 #![allow(clippy::module_name_repetitions)]
 
-use std::{
-    borrow::Cow,
+use alloc::{borrow::Cow, boxed::Box, string::String, vec::Vec};
+use core::{
     hash::{BuildHasher, Hasher},
     ops::{Index, IndexMut},
 };
@@ -218,7 +218,7 @@ impl LoadableYamlNode<'_> for YamlOwned {
 
     fn take(&mut self) -> Self {
         let mut taken_out = Self::BadValue;
-        std::mem::swap(&mut taken_out, self);
+        core::mem::swap(&mut taken_out, self);
         taken_out
     }
 }
@@ -236,7 +236,7 @@ impl IntoIterator for YamlOwned {
 
 /// An iterator over a [`YamlOwned`] node.
 pub struct YamlOwnedIter {
-    yaml: std::vec::IntoIter<YamlOwned>,
+    yaml: alloc::vec::IntoIter<YamlOwned>,
 }
 
 impl Iterator for YamlOwnedIter {
@@ -249,7 +249,7 @@ impl Iterator for YamlOwnedIter {
 
 /// Hash the given `str` as if it were a [`ScalarOwned::String`] object.
 fn hash_str_as_yaml_string<H: Hasher>(key: &str, mut hasher: H) -> u64 {
-    use std::hash::Hash;
+    use core::hash::Hash;
     let key = YamlOwned::Value(ScalarOwned::String(key.into()));
     key.hash(&mut hasher);
     hasher.finish()


### PR DESCRIPTION
# Objective

Add `no_std` support while preserving the API as-is as much as possible. Since this project is still in an early pre-1.0 form, adding `no_std` support now will avoid possibly breaking changes later in its life.

## Solution

- Switched to `hashbrown::HashMap` from `std::collections::HashMap`. This dependency was already in-tree and is only used internally, so no public facing change.
- Switched to deriving `thiserror::Error` instead of manual `Error` implementation. This is done to preserve the 1.65 MSRV (since `thiserror` correctly handles choosing between `core::error::Error` and `std::error::Error` based on compiler version). This dependency is used in tests already, but is now a proper dependency.
- Ensured `saphyr-parser` and `saphyr` compile for `no_std` targets such as `wasm32v1-none` and `x86_64-unknown-none`. Added this to CI to ensure compatibility doesn't regress.
- Marked `sahpyr::loader::LoadError` as `non_exhaustive` to handle the `IO` variant in `no_std` contexts. This is the only breaking change in this PR.

---

## Notes

- `serde` is also `no_std` compatible, so a future version of this crate with `serde` compatibility can still be `no_std`.
- I've deliberately _not_ added `std` features to either `saphyr` or `saphyr_parser`. The existing `debug_prints` and `encoding` features perfectly isolate the `std` functionality already, so an extra feature wouldn't really add anything.
- I've marked the crates as always `no_std` using `#![no_std]`, rather than using `cfg_attr(...)` to conditionally enable `no_std` support. This is a deliberate choice to avoid changes in the implicit prelude, which can cause extremely annoying CI failures based on feature combinations.
- The one and only use of `alloc::sync::Arc` is currently feature-gated on `saphyr/encoding`, this has the added benefit of supporting platforms with partial atomic support (e.g., Raspberry Pi Pico, etc.). In the future, if `Arc` is required even in `no_std` contexts, I would recommend using `portable_atomic` and `portable_atomic_util` to maintain support for those platforms.