### PR TITLE
Add Clone implementation for Parser and Scanner

### DIFF
--- a/parser/src/input/buffered.rs
+++ b/parser/src/input/buffered.rs
@@ -23,6 +23,7 @@ const BUFFER_LEN: usize = 16;
 /// There is no "easy" way of doing this without itertools. In order to avoid pulling the entierty
 /// of itertools for one method, we use this structure.
 #[allow(clippy::module_name_repetitions)]
+#[derive(Clone)]
 pub struct BufferedInput<T: Iterator<Item = char>> {
     /// The iterator source,
     input: T,

--- a/parser/src/input/str.rs
+++ b/parser/src/input/str.rs
@@ -8,6 +8,7 @@ use alloc::string::String;
 
 /// A parser input that uses a `&str` as source.
 #[allow(clippy::module_name_repetitions)]
+#[derive(Clone, Copy)]
 pub struct StrInput<'a> {
     /// The input str buffer.
     buffer: &'a str,

--- a/parser/src/parser.rs
+++ b/parser/src/parser.rs
@@ -181,6 +181,23 @@ pub struct Parser<'input, T: Input> {
     keep_tags: bool,
 }
 
+impl<'input, T: Input + Clone> Clone for Parser<'input, T> {
+    fn clone(&self) -> Self {
+        Self {
+            scanner: self.scanner.clone(),
+            states: self.states.clone(),
+            state: self.state,
+            token: self.token.clone(),
+            current: self.current.clone(),
+            anchors: self.anchors.clone(),
+            anchor_id_count: self.anchor_id_count,
+            tags: self.tags.clone(),
+            stream_end_emitted: self.stream_end_emitted,
+            keep_tags: self.keep_tags,
+        }
+    }
+}
+
 /// Trait to be implemented in order to use the low-level parsing API.
 ///
 /// The low-level parsing API is event-based (a push parser), calling [`EventReceiver::on_event`]

--- a/parser/src/scanner.rs
+++ b/parser/src/scanner.rs
@@ -373,7 +373,7 @@ struct Indent {
 ///
 /// [`FlowMappingStart`]: TokenType::FlowMappingStart
 /// [`FlowMappingEnd`]: TokenType::FlowMappingEnd
-#[derive(Debug, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 enum ImplicitMappingState {
     /// It is possible there is an implicit mapping.
     ///
@@ -467,6 +467,33 @@ pub struct Scanner<'input, T> {
     buf_leading_break: String,
     buf_trailing_breaks: String,
     buf_whitespaces: String,
+}
+
+impl<'input, T: Input + Clone> Clone for Scanner<'input, T> {
+    fn clone(&self) -> Self {
+        Self {
+            input: self.input.clone(),
+            mark: self.mark,
+            tokens: self.tokens.clone(),
+            error: self.error.clone(),
+            stream_start_produced: self.stream_start_produced,
+            stream_end_produced: self.stream_end_produced,
+            adjacent_value_allowed_at: self.adjacent_value_allowed_at,
+            simple_key_allowed: self.simple_key_allowed,
+            simple_keys: self.simple_keys.clone(),
+            indent: self.indent,
+            indents: self.indents.clone(),
+            flow_level: self.flow_level,
+            tokens_parsed: self.tokens_parsed,
+            token_available: self.token_available,
+            leading_whitespace: self.leading_whitespace,
+            flow_mapping_started: self.flow_mapping_started,
+            implicit_flow_mapping_states: self.implicit_flow_mapping_states.clone(),
+            buf_leading_break: self.buf_leading_break.clone(),
+            buf_trailing_breaks: self.buf_trailing_breaks.clone(),
+            buf_whitespaces: self.buf_whitespaces.clone(),
+        }
+    }
 }
 
 impl<'input, T: Input> Iterator for Scanner<'input, T> {


### PR DESCRIPTION
For a deserialization use case, it's useful for us at https://github.com/facet-rs/facet to kind of peek, not just by one event, by as many events as it takes to disambiguate things like flatten and untagged annotations on enums and structs. But it is very much look ahead and we throw away that information once we've disambiguated.

And then we would like to keep using the parser we had in the first place, the real one. So that's why I would like support to clone all the internals of the parser, which I believe should be relatively cheap, especially if the input is a slice and hopefully should not be a big maintenance burden for you?

I don't mind using a fork for a while, but I believe this is like the most promising event-based parser for YAML. And it would be nice to be on upstream :)