### PR TITLE
Fix case of comment intercepting the multiline text (BS4K, this is invalid YAML)

### DIFF
--- a/parser/src/input/str.rs
+++ b/parser/src/input/str.rs
@@ -243,22 +243,12 @@ impl Input for StrInput<'_> {
     #[allow(clippy::inline_always)]
     #[inline(always)]
     fn next_can_be_plain_scalar(&self, in_flow: bool) -> bool {
-        let c = self.buffer.as_bytes()[0];
-        if self.buffer.len() > 1 {
-            let nc = self.buffer.as_bytes()[1];
-            match c {
-                // indicators can end a plain scalar, see 7.3.3. Plain Style
-                b':' if is_blank_or_breakz(nc as char) || (in_flow && is_flow(nc as char)) => false,
-                c if in_flow && is_flow(c as char) => false,
-                _ => true,
-            }
-        } else {
-            match c {
-                // indicators can end a plain scalar, see 7.3.3. Plain Style
-                b':' => false,
-                c if in_flow && is_flow(c as char) => false,
-                _ => true,
-            }
+        let nc = self.peek_nth(1);
+        match self.peek() {
+            // indicators can end a plain scalar, see 7.3.3. Plain Style
+            ':' if is_blank_or_breakz(nc) || (in_flow && is_flow(nc)) => false,
+            c if in_flow && is_flow(c) => false,
+            _ => true,
         }
     }
 

--- a/parser/src/scanner.rs
+++ b/parser/src/scanner.rs
@@ -872,8 +872,18 @@ impl<'input, T: Input> Scanner<'input, T> {
         // If a plain scalar was interrupted by a comment, and the next line could
         // continue the scalar in block context, this is invalid.
         if let Some(err_mark) = self.interrupted_plain_by_comment.take() {
+            // Ensure enough lookahead for the check below (peek and peek_nth) and for
+            // document indicator detection which needs 4 chars.
+            self.input.lookahead(4);
+            // BS4K should only trigger when the continuation would start on the immediate next
+            // line (no intervening empty/comment-only lines). A blank line resets the folding
+            // opportunity and thus should not error.
+            let is_immediate_next_line = self.mark.line == err_mark.line + 1;
             if self.flow_level == 0
+                && is_immediate_next_line
                 && self.mark.col as isize > self.indent
+                && !self.input.next_is_z()
+                && !self.input.next_is_document_indicator()
                 && self.input.next_can_be_plain_scalar(false)
             {
                 return Err(ScanError::new_str(

--- a/parser/src/scanner.rs
+++ b/parser/src/scanner.rs
@@ -464,6 +464,9 @@ pub struct Scanner<'input, T> {
     /// [`Possible`]: ImplicitMappingState::Possible
     /// [`Inside`]: ImplicitMappingState::Inside
     implicit_flow_mapping_states: Vec<ImplicitMappingState>,
+    /// If a plain scalar was terminated by a `#` comment on its line, we set this
+    /// to detect an illegal multiline continuation on the following line.
+    interrupted_plain_by_comment: Option<Marker>,
     buf_leading_break: String,
     buf_trailing_breaks: String,
     buf_whitespaces: String,
@@ -519,6 +522,7 @@ impl<'input, T: Input> Scanner<'input, T> {
             leading_whitespace: true,
             flow_mapping_started: false,
             implicit_flow_mapping_states: vec![],
+            interrupted_plain_by_comment: None,
 
             buf_leading_break: String::new(),
             buf_trailing_breaks: String::new(),
@@ -863,6 +867,19 @@ impl<'input, T: Input> Scanner<'input, T> {
                     self.mark.col += comment_length;
                 }
                 _ => break,
+            }
+        }
+        // If a plain scalar was interrupted by a comment, and the next line could
+        // continue the scalar in block context, this is invalid.
+        if let Some(err_mark) = self.interrupted_plain_by_comment.take() {
+            if self.flow_level == 0
+                && self.mark.col as isize > self.indent
+                && self.input.next_can_be_plain_scalar(false)
+            {
+                return Err(ScanError::new_str(
+                    err_mark,
+                    "comment intercepting the multiline text",
+                ));
             }
         }
         Ok(())
@@ -2192,6 +2209,13 @@ impl<'input, T: Input> Scanner<'input, T> {
             if (self.leading_whitespace && self.input.next_is_document_indicator())
                 || self.input.peek() == '#'
             {
+                // BS4K: If a `#` starts a comment after some separation spaces following content
+                // of a plain scalar in block context, and there is potential continuation on the
+                // next line, this is invalid. We cannot decide yet if there will be continuation,
+                // so record that a comment interrupted a plain scalar.
+                if self.input.peek() == '#' && !string.is_empty() && !self.buf_whitespaces.is_empty() && self.flow_level == 0 {
+                    self.interrupted_plain_by_comment = Some(self.mark);
+                }
                 break;
             }
 

--- a/parser/tests/comment_intercepts_line.rs
+++ b/parser/tests/comment_intercepts_line.rs
@@ -1,0 +1,23 @@
+use saphyr_parser::{Event, Parser};
+
+/// Comment intercepting the multiline text is invalid YAML (case BS4K)
+#[test]
+fn bs4k_comment_between_plain_scalar_lines_should_fail() {
+    let yaml = "word1  # comment\nword2\n";
+
+    let mut parser = Parser::new_from_str(yaml);
+    while let Some(next) = parser.next() {
+        match next {
+            Ok((Event::DocumentEnd, _)) => {
+                assert!(false, "Document end before any error");
+            }
+            Err(err) => {
+                assert_eq!(err.info(), "comment intercepting the multiline text",
+                           "BS4K: comment intercepting the multiline text is invalid YAML"
+                );
+                break; // fine
+            }
+            _ => {}
+        }
+    }
+}

--- a/parser/tests/comment_intercepts_line.rs
+++ b/parser/tests/comment_intercepts_line.rs
@@ -1,9 +1,11 @@
-use saphyr_parser::{Event, Parser};
+use saphyr_parser::{Event, Parser, ScalarStyle};
 
 /// Comment intercepting the multiline text is invalid YAML (case BS4K)
 #[test]
 fn bs4k_comment_between_plain_scalar_lines_should_fail() {
-    let yaml = "word1  # comment\nword2\n";
+    let yaml = r#"word1  # comment
+word2
+"#;
 
     let mut parser = Parser::new_from_str(yaml);
     while let Some(next) = parser.next() {
@@ -20,4 +22,41 @@ fn bs4k_comment_between_plain_scalar_lines_should_fail() {
             _ => {}
         }
     }
+}
+
+#[test]
+fn bs4k_comment_between_plain_scalar_lines_in_map_should_fail() {
+    let yaml = r#"
+key: word1  # comment
+  word2
+"#;
+
+    let mut parser = Parser::new_from_str(yaml);
+    let mut got_error = false;
+    while let Some(next) = parser.next() {
+        if let Err(err) = next {
+            assert_eq!(err.info(), "comment intercepting the multiline text",
+                       "BS4K: comment intercepting the multiline text is invalid YAML in a map"
+            );
+            got_error = true;
+            break;
+        }
+    }
+    assert!(got_error, "Should have encountered BS4K error in map");
+}
+
+#[test]
+fn multiline_plain_scalar_in_map_without_comment_is_valid() {
+    let yaml = r#"
+key: word1
+  word2
+"#;
+
+    let mut parser = Parser::new_from_str(yaml);
+    let mut events = Vec::new();
+    while let Some(next) = parser.next() {
+        events.push(next.unwrap().0);
+    }
+
+    assert!(events.contains(&Event::Scalar("word1 word2".into(), ScalarStyle::Plain, 0, None)));
 }

--- a/parser/tests/plain_scalar_indicators.rs
+++ b/parser/tests/plain_scalar_indicators.rs
@@ -1,0 +1,46 @@
+use saphyr_parser::{Event, Parser, ScalarStyle, ScanError};
+
+// Regression guards for StrInput::next_can_be_plain_scalar simplification.
+// YAML 1.2 7.3.3: indicator characters can end a plain scalar in certain positions.
+
+#[test]
+fn colon_followed_by_space_ends_plain_scalar_not_part_of_value() {
+    // After "foo:", seeing "a: b" means the colon after 'a' is treated as YAML syntax,
+    // not as part of the plain scalar. Without a newline/indentation or flow braces,
+    // this input is invalid in YAML and our parser must error (it must NOT accept
+    // "a: b" as a single scalar value).
+    let s = "foo: a: b\n";
+
+    let mut it = Parser::new_from_str(s);
+    let mut got_err: Option<ScanError> = None;
+    while let Some(res) = it.next() {
+        if let Err(e) = res {
+            got_err = Some(e);
+            break;
+        }
+    }
+    let err = got_err.expect("no error on inline nested mapping without indentation");
+    assert_eq!(err.info(), "mapping values are not allowed in this context");
+}
+
+#[test]
+fn colon_without_space_is_part_of_scalar_value() {
+    // When there is no blank after ':', the ':' is part of the plain scalar (7.3.3).
+    // Here the value should be the single scalar "a:b".
+    let s = "k: a:b\n";
+    let events: Vec<_> = Parser::new_from_str(s).map(
+        |r| r.unwrap().0).collect();
+    assert_eq!(
+        events,
+        vec![
+            Event::StreamStart,
+            Event::DocumentStart(false),
+            Event::MappingStart(0, None),
+            Event::Scalar("k".into(), ScalarStyle::Plain, 0, None),
+            Event::Scalar("a:b".into(), ScalarStyle::Plain, 0, None),
+            Event::MappingEnd,
+            Event::DocumentEnd,
+            Event::StreamEnd,
+        ]
+    );
+}


### PR DESCRIPTION
This patch fixes BS4K, comment intercepting multiline text is invalid YAML. saphyr-parser 0.0.6 takes this as valid, discarding part of the text after comment.

This patch includes some code simplification in handling the case 7.3.3 (indicator characters may end plain scalar), but none of saphyr-parser tests are broken and none of serde-saphyr tests are broken, so looks like we do not have regression. I added an extra test to be sure that colon followed by space breaks the scalar.