### PR TITLE
Fix: whole floats emit as ints

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,1 @@
+hard_tabs = false

--- a/saphyr/src/emitter.rs
+++ b/saphyr/src/emitter.rs
@@ -218,7 +218,11 @@ impl<'a> YamlEmitter<'a> {
                 Ok(())
             }
             Yaml::Value(Scalar::Integer(v)) => Ok(write!(self.writer, "{v}")?),
-            Yaml::Value(Scalar::FloatingPoint(ref v)) => Ok(write!(self.writer, "{v}")?),
+            Yaml::Value(Scalar::FloatingPoint(ref v)) => Ok(write!(
+                self.writer,
+                "{v}{}",
+                if v.fract() == 0.0 { ".0" } else { "" }
+            )?),
             Yaml::Value(Scalar::Null) | Yaml::BadValue => Ok(write!(self.writer, "~")?),
             Yaml::Representation(ref v, style, ref tag) => {
                 if let Some(tag) = tag {


### PR DESCRIPTION
Whole floats like `0` will be emitted as `0`, which parses to an int, causing round trip failures. This commit adds `.0` to the ends of whole floats to make them parse as floats.