### PR TITLE
Fix indentation check rejecting valid multi-line flow collections

### DIFF
--- a/parser/src/scanner.rs
+++ b/parser/src/scanner.rs
@@ -697,7 +697,10 @@ impl<'input, T: Input> Scanner<'input, T> {
             }
         }
 
-        if (self.mark.col as isize) < self.indent {
+        // Indentation rules only apply in block contexts. Inside flow-style
+        // collections (`[...]`, `{...}`), indentation is not significant per
+        // the YAML spec (§8.1.1), so we skip this check when flow_level > 0.
+        if self.flow_level == 0 && (self.mark.col as isize) < self.indent {
             return Err(ScanError::new_str(self.mark, "invalid indentation"));
         }
 

--- a/parser/tests/issues.rs
+++ b/parser/tests/issues.rs
@@ -404,3 +404,74 @@ fn test_issue37() {
         ]
     );
 }
+
+#[test]
+fn test_multiline_flow_sequence_in_block() {
+    // Multi-line flow sequences inside block mappings should be valid YAML.
+    // The closing `]` may appear at any indentation level inside a flow collection.
+    let s = r#"
+root:
+  key: [
+    "a",
+    "b",
+    "c"
+  ]
+"#;
+    let events = run_parser(s).unwrap();
+    assert_eq!(
+        events,
+        [
+            Event::StreamStart,
+            Event::DocumentStart(false),
+            Event::MappingStart(0, None),
+            Event::Scalar("root".into(), ScalarStyle::Plain, 0, None),
+            Event::MappingStart(0, None),
+            Event::Scalar("key".into(), ScalarStyle::Plain, 0, None),
+            Event::SequenceStart(0, None),
+            Event::Scalar("a".into(), ScalarStyle::DoubleQuoted, 0, None),
+            Event::Scalar("b".into(), ScalarStyle::DoubleQuoted, 0, None),
+            Event::Scalar("c".into(), ScalarStyle::DoubleQuoted, 0, None),
+            Event::SequenceEnd,
+            Event::MappingEnd,
+            Event::MappingEnd,
+            Event::DocumentEnd,
+            Event::StreamEnd,
+        ]
+    );
+}
+
+#[test]
+fn test_multiline_flow_sequence_deep_nesting() {
+    // Multi-line flow sequence deeply nested in block structure
+    let s = r#"
+a:
+  b:
+    c:
+      d: [
+        "value1",
+        "value2"
+      ]
+"#;
+    assert!(run_parser(s).is_ok());
+}
+
+#[test]
+fn test_multiline_flow_mapping_in_block() {
+    // Multi-line flow mappings inside block mappings should be valid YAML.
+    let s = r#"
+root:
+  key: {
+    "a": 1,
+    "b": 2
+  }
+"#;
+    assert!(run_parser(s).is_ok());
+}
+
+#[test]
+fn test_multiline_flow_sequence_closing_at_lower_indent() {
+    // The closing bracket at a column lower than the block indent level
+    // This is the exact pattern that caused the saphyr-parser bug
+    let s = "            TopLevel:\n              SubLevel: [\n                \"first-entry\",\n                \"second-entry\"\n              ]\n            Foo: bar\n";
+    assert!(run_parser(s).is_ok());
+}


### PR DESCRIPTION
## Problem
Multi-line flow sequences and mappings inside block contexts are incorrectly
rejected with an `invalid indentation` error. For example, this valid YAML fails:

```yaml
root:
  key: [
    "a",
    "b"
  ]
````

The closing `]` on a new line triggers the indentation check in `fetch_next_token()`, which compares the column against the block indentation level. However, per the YAML spec §8.1.1, indentation is not significant inside flow-style collections.

## Fix

Added a `flow_level == 0` guard to the indentation check so it only applies in block contexts. This is consistent with how other indentation checks in the scanner already behave (e.g., `unroll_indent`, `roll_indent`, `stale_simple_keys`).

## Tests

Added 4 regression tests covering:

- Multi-line flow sequence in block mapping
- Deeply nested multi-line flow sequence
- Multi-line flow mapping in block mapping
- Closing bracket at lower indent than block level

All existing 402 tests continue to pass.
