### PR TITLE
fix: bound anchor alias expansion to defend against billion-laughs (#109)

### DIFF
--- a/saphyr/src/loader.rs
+++ b/saphyr/src/loader.rs
@@ -36,7 +36,21 @@ where
     marker: PhantomData<&'input u32>,
     /// See [`Self::early_parse()`]
     early_parse: bool,
+    /// See [`Self::alias_node_budget()`]
+    alias_node_budget: usize,
+    /// Set once alias expansion exceeds `alias_node_budget`. Surfaced by
+    /// [`LoadableYamlNode::load_from_parser`].
+    alias_error: Option<ScanError>,
 }
+
+/// Default budget (in nodes) for anchor alias expansion, used unless
+/// [`YamlLoader::alias_node_budget`] overrides it.
+///
+/// Resolving an [`Event::Alias`] clones the anchor's already-built subtree. Without a
+/// limit, a handful of nested anchors can be crafted to expand into an exponential number
+/// of nodes (a "billion laughs" attack), exhausting memory. See
+/// <https://github.com/saphyr-rs/saphyr/issues/109>.
+pub const DEFAULT_ALIAS_NODE_BUDGET: usize = 100_000;
 
 /// A trait providing methods used by the [`YamlLoader`].
 ///
@@ -210,6 +224,9 @@ pub trait LoadableYamlNode<'input>: Clone + core::hash::Hash + Eq {
     fn load_from_parser<I: Input>(parser: &mut Parser<'input, I>) -> Result<Vec<Self>, ScanError> {
         let mut loader = YamlLoader::default();
         parser.load(&mut loader, true)?;
+        if let Some(err) = loader.alias_error.take() {
+            return Err(err);
+        }
         Ok(loader.into_documents())
     }
 }
@@ -230,6 +247,19 @@ where
     /// [`Scalar`]: crate::Scalar
     pub fn early_parse(&mut self, enabled: bool) {
         self.early_parse = enabled;
+    }
+
+    /// Set the maximum number of nodes that anchor alias expansion may produce.
+    ///
+    /// Resolving an [`Event::Alias`] clones the anchor's already-built subtree. Without a
+    /// limit, a handful of nested anchors can be crafted to expand into an exponential
+    /// number of nodes (a "billion laughs" attack), exhausting memory: see
+    /// <https://github.com/saphyr-rs/saphyr/issues/109>. This budget bounds the total
+    /// number of nodes that may be produced via alias resolution across the whole load,
+    /// beyond which loading fails with a [`ScanError`]. Defaults to
+    /// [`DEFAULT_ALIAS_NODE_BUDGET`].
+    pub fn alias_node_budget(&mut self, budget: usize) {
+        self.alias_node_budget = budget;
     }
 
     /// Return the document nodes from `self`, consuming it in the process.
@@ -297,10 +327,7 @@ where
                 self.insert_new_node(Node::from_bare_yaml(node).with_span(span), aid, tag);
             }
             Event::Alias(id) => {
-                let n = match self.anchor_map.get(&id) {
-                    Some(v) => v.clone(),
-                    None => Node::from_bare_yaml(Yaml::BadValue),
-                };
+                let n = self.resolve_alias(id, mark);
                 self.insert_new_node(n.with_span(span), 0, None);
             }
         }
@@ -311,6 +338,35 @@ impl<'input, Node> YamlLoader<'input, Node>
 where
     Node: LoadableYamlNode<'input>,
 {
+    /// Resolve an [`Event::Alias`] by cloning the referenced anchor's subtree.
+    ///
+    /// Returns a `BadValue` node, without cloning, if the anchor is unknown or if cloning
+    /// it would push the total number of alias-produced nodes past `self.alias_node_budget`
+    /// (in which case `self.alias_error` is set, once). The anchor's size is established by
+    /// walking it directly (via a mutable borrow, so no clone is needed just to measure it),
+    /// and that walk stops as soon as the budget is exhausted, so a single oversized anchor
+    /// cannot be used to force an expensive full traversal either. See
+    /// <https://github.com/saphyr-rs/saphyr/issues/109>.
+    fn resolve_alias(&mut self, id: usize, mark: Marker) -> Node {
+        if self.alias_error.is_some() {
+            return Node::from_bare_yaml(Yaml::BadValue);
+        }
+        let Some(existing) = self.anchor_map.get_mut(&id) else {
+            return Node::from_bare_yaml(Yaml::BadValue);
+        };
+        let mut remaining = self.alias_node_budget;
+        if count_nodes_within_budget(existing, &mut remaining) {
+            self.alias_node_budget = remaining;
+            existing.clone()
+        } else {
+            self.alias_error = Some(ScanError::new_str(
+                mark,
+                "alias expansion exceeded the maximum node budget (possible billion-laughs attack)",
+            ));
+            Node::from_bare_yaml(Yaml::BadValue)
+        }
+    }
+
     fn insert_new_node(&mut self, mut node: Node, anchor_id: usize, tag: Option<Cow<'input, Tag>>) {
         // valid anchor id starts from 1
         if anchor_id > 0 {
@@ -354,8 +410,49 @@ where
             anchor_map: BTreeMap::new(),
             marker: PhantomData,
             early_parse: true,
+            alias_node_budget: DEFAULT_ALIAS_NODE_BUDGET,
+            alias_error: None,
         }
     }
+}
+
+/// Recursively count the nodes making up `node`, decrementing `budget` as it goes.
+///
+/// Stops as soon as `budget` reaches zero and returns `false` in that case, without
+/// establishing `node`'s full size (only that it exceeds `budget`). Returns `true` if the
+/// whole subtree fits within `budget`, leaving `budget` decremented by `node`'s exact node
+/// count so callers can accumulate usage across several calls instead of recomputing it.
+///
+/// Mapping keys are each counted as a single node rather than recursed into: the
+/// `LoadableYamlNode::HashKey` type isn't itself a `LoadableYamlNode`, so its structure
+/// isn't visible here. In practice alias-bomb payloads use sequence fan-out (as in the
+/// reported attack), so this is not a gap in the defense the budget is meant to provide.
+fn count_nodes_within_budget<'input, Node>(node: &mut Node, budget: &mut usize) -> bool
+where
+    Node: LoadableYamlNode<'input>,
+{
+    if *budget == 0 {
+        return false;
+    }
+    *budget -= 1;
+    if node.is_sequence() {
+        for child in node.sequence_mut() {
+            if !count_nodes_within_budget(child, budget) {
+                return false;
+            }
+        }
+    } else if node.is_mapping() {
+        for (_, value) in node.mapping_mut().iter_mut() {
+            if *budget == 0 {
+                return false;
+            }
+            *budget -= 1;
+            if !count_nodes_within_budget(value, budget) {
+                return false;
+            }
+        }
+    }
+    true
 }
 
 /// An error that happened when loading a YAML document.

--- a/saphyr/tests/basic.rs
+++ b/saphyr/tests/basic.rs
@@ -84,6 +84,44 @@ a1: &DEFAULT
 }
 
 #[test]
+fn test_legitimate_alias_fanout_is_not_rejected() {
+    // Five levels of 9-way anchor reuse materialize ~14k nodes (well under the
+    // default 100_000-node alias budget) and must still load normally.
+    let s = "
+a: &a [\"lol\"]
+b: &b [*a,*a,*a,*a,*a,*a,*a,*a,*a]
+c: &c [*b,*b,*b,*b,*b,*b,*b,*b,*b]
+d: &d [*c,*c,*c,*c,*c,*c,*c,*c,*c]
+e: [*d,*d,*d,*d,*d,*d,*d,*d,*d]
+";
+    let docs = Yaml::load_from_str(s).unwrap();
+    assert_eq!(docs.len(), 1);
+}
+
+#[test]
+fn test_alias_bomb_is_rejected() {
+    // Regression test for https://github.com/saphyr-rs/saphyr/issues/109 (YAML
+    // "billion laughs" alias-bomb): unconditional deep-cloning of anchor subtrees
+    // during Event::Alias resolution let a tiny nested-anchor payload expand into
+    // an exponential number of nodes, exhausting memory. This is the same 9-way
+    // fan-out from the issue, but truncated to six anchor levels: that already
+    // materializes ~125k nodes through alias resolution alone (crossing the
+    // default 100_000-node budget), while staying cheap enough to actually
+    // allocate here -- the issue's full 9-level payload legitimately tries to
+    // produce ~43 million nodes, which is unsafe to run in a test.
+    let s = "
+a: &a [\"lol\"]
+b: &b [*a,*a,*a,*a,*a,*a,*a,*a,*a]
+c: &c [*b,*b,*b,*b,*b,*b,*b,*b,*b]
+d: &d [*c,*c,*c,*c,*c,*c,*c,*c,*c]
+e: &e [*d,*d,*d,*d,*d,*d,*d,*d,*d]
+f: [*e,*e,*e,*e,*e,*e,*e,*e,*e]
+";
+    let err = Yaml::load_from_str(s).expect_err("alias bomb should be rejected");
+    assert!(err.to_string().contains("alias"), "unexpected error: {err}");
+}
+
+#[test]
 fn test_plain_datatype() {
     let s = "
 - 'string'


### PR DESCRIPTION
## Problem
Fixes #109. `YamlLoader` had no limit on anchor alias expansion, so a small (~350 byte) YAML payload with nested anchors could expand into tens of millions of nodes in memory (a "billion laughs" / alias-bomb attack), OOM-killing or hanging any process that parses untrusted YAML. Confirmed on master HEAD 044179e.

## Root cause
In `src/loader.rs`, the `Event::Alias(id)` arm deep-cloned the anchor's already-expanded subtree unconditionally:
```rust
Event::Alias(id) => {
    let n = match self.anchor_map.get(&id) {
        Some(v) => v.clone(),
        None => Node::from_bare_yaml(Yaml::BadValue),
    };
    ...
}
```
Each alias resolution copies an already-materialized subtree, so nesting anchors N levels deep with each referencing the previous one K times multiplies total node count roughly as K^N, independent of input size.

## Fix
Added a node budget (`YamlLoader::alias_node_budget`, default `DEFAULT_ALIAS_NODE_BUDGET = 100_000`) tracked across the whole load. Before cloning an anchor on `Event::Alias`, `resolve_alias` walks the anchor's existing subtree via a mutable borrow (no clone needed just to measure it) and counts its size against the remaining budget. The walk short-circuits as soon as the budget is exhausted, so an oversized anchor can't force an expensive full traversal either, and the clone itself never happens once the budget would be exceeded. If exceeded, loading fails with a `ScanError` instead of continuing to expand. No API changes for existing callers; `alias_node_budget()` is a new opt-in builder method (mirrors the existing `early_parse()`).

One known scope limit: mapping keys are counted as a single node each rather than recursed into (`LoadableYamlNode::HashKey` isn't itself a `LoadableYamlNode`, so its structure isn't visible to the counter). Alias-bomb payloads use sequence fan-out in practice (including the one in this issue), so this isn't a gap in the defense as reported, but a future PR could tighten it if that changes.

## How to test
```
$ cargo test -p saphyr --test basic -- alias anchor
running 4 tests
test test_anchor ... ok
test test_bad_anchor ... ok
test test_legitimate_alias_fanout_is_not_rejected ... ok
test test_alias_bomb_is_rejected ... ok
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.04s
```
`test_alias_bomb_is_rejected` fails on unpatched `loader.rs` (loads successfully instead of erroring) and passes with the fix -- verified by stashing the source change and re-running. It uses a truncated (6-level, not the issue's 9-level) version of the reported payload: enough to cross the default budget (~125k nodes) while staying cheap enough to actually allocate in a test, since the full 9-level payload legitimately tries to produce ~43 million nodes.

Full suite: `cargo test -p saphyr` -- all green. `cargo clippy -p saphyr --all-targets -- -D warnings` and `cargo fmt --check` -- clean.

## Backward compatibility
No breaking changes. Existing callers get the 100k default budget automatically; callers who construct a `YamlLoader` directly can call `.alias_node_budget(n)` to raise or lower it.

---
Assisted-by: Claude (code generation, reviewed and tested locally)
