### PR TITLE
Fix core schema tags resolving more narrowly than untagged scalars

### DIFF
--- a/saphyr/CHANGELOG.md
+++ b/saphyr/CHANGELOG.md
@@ -7,6 +7,22 @@
 - Whole floats such as `100.0` were being emitted as integers by `YamlEmitter`.
 Whole floats now include a `.0` suffix when emitted to correct this behavior.
 ([+97](https://github.com/saphyr-rs/saphyr/pull/97))
+- Core schema tags no longer resolve more narrowly than untagged scalars. `!!int 0x1F`,
+`!!bool TRUE` and `!!null NULL` used to yield a `BadValue` although the same representations
+resolve fine without a tag.
+([#122](https://github.com/saphyr-rs/saphyr/pull/122))
+- An empty node now resolves to `Null` even when it carries an anchor. `a: &anchor` used to
+yield an empty string.
+([#122](https://github.com/saphyr-rs/saphyr/pull/122))
+- The implicit resolver no longer accepts integers the core schema rejects, such as `0x-1F`
+and `++7`.
+([#122](https://github.com/saphyr-rs/saphyr/pull/122))
+
+**Additions**:
+
+- `is_core_schema_null`, `parse_core_schema_bool` and `parse_core_schema_int`, alongside the
+existing `parse_core_schema_fp`.
+([#122](https://github.com/saphyr-rs/saphyr/pull/122))
 
 
 ## v0.0.11

--- a/saphyr/src/lib.rs
+++ b/saphyr/src/lib.rs
@@ -155,7 +155,10 @@ pub use crate::annotated::{
 pub use crate::emitter::{EmitError, YamlEmitter};
 pub use crate::index::{Accessor, SafelyIndex, SafelyIndexMut};
 pub use crate::loader::{LoadError, LoadableYamlNode, YamlLoader};
-pub use crate::scalar::{Scalar, ScalarOwned, parse_core_schema_fp};
+pub use crate::scalar::{
+    Scalar, ScalarOwned, is_core_schema_null, parse_core_schema_bool, parse_core_schema_fp,
+    parse_core_schema_int,
+};
 pub use crate::yaml::{Mapping, Sequence, Yaml, YamlIter};
 pub use crate::yaml_owned::{MappingOwned, SequenceOwned, YamlOwned, YamlOwnedIter};
 

--- a/saphyr/src/scalar.rs
+++ b/saphyr/src/scalar.rs
@@ -142,15 +142,12 @@ impl<'input> Scalar<'input> {
         } else if let Some(tag) = tag.map(Cow::as_ref) {
             if tag.is_yaml_core_schema() {
                 match tag.suffix.as_ref() {
-                    "bool" => v.parse::<bool>().ok().map(Self::Boolean),
-                    "int" => v.parse::<i64>().ok().map(Self::Integer),
+                    "bool" => parse_core_schema_bool(&v).map(Self::Boolean),
+                    "int" => parse_core_schema_int(&v).map(Self::Integer),
                     "float" => parse_core_schema_fp(&v)
                         .map(OrderedFloat)
                         .map(Self::FloatingPoint),
-                    "null" => match v.as_ref() {
-                        "~" | "null" => Some(Self::Null),
-                        _ => None,
-                    },
+                    "null" => is_core_schema_null(&v).then_some(Self::Null),
                     "str" => Some(Self::String(v)),
                     // If we have a tag we do not recognize, return `None`.
                     _ => None,
@@ -176,54 +173,18 @@ impl<'input> Scalar<'input> {
     #[must_use]
     pub fn parse_from_cow(v: Cow<'input, str>) -> Self {
         let s = &*v;
-        let bytes = s.as_bytes();
 
-        if bytes.len() >= 2 {
-            match (bytes[0], bytes[1]) {
-                (b'0', b'x') => {
-                    if let Ok(i) = i64::from_str_radix(&s[2..], 16) {
-                        return Self::Integer(i);
-                    }
-                }
-                (b'0', b'o') => {
-                    if let Ok(i) = i64::from_str_radix(&s[2..], 8) {
-                        return Self::Integer(i);
-                    }
-                }
-                (b'+', _) => {
-                    if let Ok(i) = s[1..].parse::<i64>() {
-                        return Self::Integer(i);
-                    }
-                }
-                _ => {}
-            }
+        if is_core_schema_null(s) {
+            Self::Null
+        } else if let Some(b) = parse_core_schema_bool(s) {
+            Self::Boolean(b)
+        } else if let Some(i) = parse_core_schema_int(s) {
+            Self::Integer(i)
+        } else if let Some(f) = parse_core_schema_fp(s) {
+            Self::FloatingPoint(f.into())
+        } else {
+            Self::String(v)
         }
-
-        match bytes.len() {
-            1 if bytes[0] == b'~' => return Self::Null,
-            4 => {
-                let f = bytes[0] & 0xDF;
-                if f == b'N' && matches!(s, "null" | "Null" | "NULL") {
-                    return Self::Null;
-                } else if f == b'T' && matches!(s, "true" | "True" | "TRUE") {
-                    return Self::Boolean(true);
-                }
-            }
-            5 if matches!(s, "false" | "False" | "FALSE") => {
-                return Self::Boolean(false);
-            }
-            _ => {}
-        }
-
-        if let Ok(integer) = s.parse::<i64>() {
-            return Self::Integer(integer);
-        }
-
-        if let Some(float) = parse_core_schema_fp(s) {
-            return Self::FloatingPoint(float.into());
-        }
-
-        Self::String(v)
     }
 }
 
@@ -296,6 +257,58 @@ impl<'input> From<&'input ScalarOwned> for Scalar<'input> {
     fn from(value: &'input ScalarOwned) -> Self {
         value.as_scalar()
     }
+}
+
+/// Return whether the given string is a null according to the core schema.
+///
+/// See [10.2.1.1](https://yaml.org/spec/1.2.2/#10211-null) for the null definition. Note that an
+/// empty representation resolves to null, which is how an anchored-but-valueless node such as
+/// `key: &anchor` is spelled.
+#[must_use]
+pub fn is_core_schema_null(v: &str) -> bool {
+    matches!(v, "" | "~" | "null" | "Null" | "NULL")
+}
+
+/// Parse the given string as a boolean according to the core schema.
+///
+/// See [10.2.1.2](https://yaml.org/spec/1.2.2/#10212-boolean) for the boolean definition.
+///
+/// # Return
+/// Returns `Some` if parsing succeeded, `None` otherwise. As with [`parse_core_schema_fp`], failing
+/// to parse is not an error, so this does not return a `Result`.
+#[must_use]
+pub fn parse_core_schema_bool(v: &str) -> Option<bool> {
+    match v {
+        "true" | "True" | "TRUE" => Some(true),
+        "false" | "False" | "FALSE" => Some(false),
+        _ => None,
+    }
+}
+
+/// Parse the given string as an integer according to the core schema.
+///
+/// See [10.2.1.3](https://yaml.org/spec/1.2.2/#10213-integer) for the integer definition.
+///
+/// # Return
+/// Returns `Some` if parsing succeeded, `None` otherwise. As with [`parse_core_schema_fp`], failing
+/// to parse is not an error, so this does not return a `Result`.
+#[must_use]
+pub fn parse_core_schema_int(v: &str) -> Option<i64> {
+    // `0x`/`0o` take no sign, but `from_str_radix` accepts one, hence the digit check.
+    if let Some(digits) = v.strip_prefix("0x") {
+        if digits.is_empty() || !digits.bytes().all(|b| b.is_ascii_hexdigit()) {
+            return None;
+        }
+        return i64::from_str_radix(digits, 16).ok();
+    }
+    if let Some(digits) = v.strip_prefix("0o") {
+        if digits.is_empty() || !digits.bytes().all(|b| matches!(b, b'0'..=b'7')) {
+            return None;
+        }
+        return i64::from_str_radix(digits, 8).ok();
+    }
+    // Base 10 is `[-+]?[0-9]+`, which is exactly what `i64`'s own parser accepts.
+    v.parse::<i64>().ok()
 }
 
 /// Parse the given string as a floating point according to the core schema.

--- a/saphyr/tests/core_schema.rs
+++ b/saphyr/tests/core_schema.rs
@@ -1,0 +1,213 @@
+//! Resolution of scalars against the [YAML 1.2 Core Schema].
+//!
+//! [YAML 1.2 Core Schema]: https://yaml.org/spec/1.2.2/#103-core-schema
+
+use std::borrow::Cow;
+
+use saphyr::{LoadableYamlNode, Scalar, ScalarStyle, Tag, Yaml};
+
+fn implicit(v: &str) -> Scalar<'_> {
+    Scalar::parse_from_cow(v.into())
+}
+
+fn tagged<'a>(v: &'a str, suffix: &str) -> Option<Scalar<'a>> {
+    let tag = Cow::Owned(Tag {
+        handle: "tag:yaml.org,2002:".into(),
+        suffix: suffix.into(),
+    });
+    Scalar::parse_from_cow_and_metadata(v.into(), ScalarStyle::Plain, Some(&tag))
+}
+
+fn f(v: f64) -> Scalar<'static> {
+    Scalar::FloatingPoint(v.into())
+}
+
+fn s(v: &str) -> Scalar<'_> {
+    Scalar::String(v.into())
+}
+
+/// Every representation of the [table] in <https://yaml.org/spec/1.2.2/#103-core-schema>, with the
+/// near-misses that must *not* resolve to the same tag.
+fn corpus() -> Vec<(&'static str, Scalar<'static>)> {
+    vec![
+        // null: `null | Null | NULL | ~` and the empty representation.
+        ("", Scalar::Null),
+        ("~", Scalar::Null),
+        ("null", Scalar::Null),
+        ("Null", Scalar::Null),
+        ("NULL", Scalar::Null),
+        ("nULL", s("nULL")),
+        ("None", s("None")),
+        ("nil", s("nil")),
+        // bool: `true | True | TRUE | false | False | FALSE`.
+        ("true", Scalar::Boolean(true)),
+        ("True", Scalar::Boolean(true)),
+        ("TRUE", Scalar::Boolean(true)),
+        ("false", Scalar::Boolean(false)),
+        ("False", Scalar::Boolean(false)),
+        ("FALSE", Scalar::Boolean(false)),
+        ("tRUE", s("tRUE")),
+        // YAML 1.1 booleans, dropped by the 1.2 core schema.
+        ("yes", s("yes")),
+        ("No", s("No")),
+        ("on", s("on")),
+        // int, base 10: `[-+]?[0-9]+`.
+        ("0", Scalar::Integer(0)),
+        ("7", Scalar::Integer(7)),
+        ("007", Scalar::Integer(7)),
+        ("-7", Scalar::Integer(-7)),
+        ("+7", Scalar::Integer(7)),
+        ("+0", Scalar::Integer(0)),
+        ("-0", Scalar::Integer(0)),
+        ("++7", s("++7")),
+        ("+-7", s("+-7")),
+        ("1_000", s("1_000")),
+        ("+", s("+")),
+        // int, base 8: `0o[0-7]+`.
+        ("0o17", Scalar::Integer(15)),
+        ("0o0", Scalar::Integer(0)),
+        ("0o", s("0o")),
+        ("0o8", s("0o8")),
+        ("0O17", s("0O17")),
+        ("-0o17", s("-0o17")),
+        ("0o+17", s("0o+17")),
+        ("0o-17", s("0o-17")),
+        // int, base 16: `0x[0-9a-fA-F]+`.
+        ("0x1F", Scalar::Integer(31)),
+        ("0x00FF", Scalar::Integer(255)),
+        ("0x", s("0x")),
+        ("0xG", s("0xG")),
+        ("0X1F", s("0X1F")),
+        ("-0x1F", s("-0x1F")),
+        ("+0x1F", s("+0x1F")),
+        ("0x+1F", s("0x+1F")),
+        ("0x-1F", s("0x-1F")),
+        // No base 2 in the core schema.
+        ("0b101", s("0b101")),
+        // float.
+        ("1.5", f(1.5)),
+        ("-1.5", f(-1.5)),
+        ("+.5", f(0.5)),
+        ("1.", f(1.0)),
+        ("1e3", f(1000.0)),
+        ("1.5e-3", f(0.0015)),
+        (".inf", f(f64::INFINITY)),
+        ("+.Inf", f(f64::INFINITY)),
+        ("-.INF", f(f64::NEG_INFINITY)),
+        (".nan", f(f64::NAN)),
+        ("inf", s("inf")),
+        ("nan", s("nan")),
+        // str, the default.
+        ("abc", s("abc")),
+        ("0x1F ", s("0x1F ")),
+    ]
+}
+
+/// The implicit resolver must agree with the core schema table.
+#[test]
+fn implicit_resolution_follows_the_core_schema() {
+    for (repr, expected) in corpus() {
+        assert_eq!(implicit(repr), expected, "implicit resolution of {repr:?}");
+    }
+}
+
+/// A `!!null`/`!!bool`/`!!int` tag must accept exactly what the implicit resolver resolves to that
+/// type, and yield the same value. Without this, writing the tag that asserts a scalar's type is
+/// what stops saphyr from parsing it.
+#[test]
+fn explicit_tag_agrees_with_implicit_resolution() {
+    for (repr, expected) in corpus() {
+        for (suffix, matches) in [
+            ("null", matches!(expected, Scalar::Null)),
+            ("bool", matches!(expected, Scalar::Boolean(_))),
+            ("int", matches!(expected, Scalar::Integer(_))),
+        ] {
+            let got = tagged(repr, suffix);
+            let want = matches.then(|| expected.clone());
+            assert_eq!(got, want, "!!{suffix} {repr:?} vs untagged {expected:?}");
+        }
+    }
+}
+
+/// `!!float` additionally accepts base 10 integers (the float regexp subsumes `[-+]?[0-9]+`, but
+/// not the `0o`/`0x` forms), and `!!str` accepts anything.
+#[test]
+fn float_and_str_tags_accept_their_supersets() {
+    for (repr, expected) in corpus() {
+        assert_eq!(tagged(repr, "str"), Some(s(repr)), "!!str {repr:?}");
+        let want = match expected {
+            Scalar::Integer(i) if !repr.starts_with("0o") && !repr.starts_with("0x") => {
+                Some(f(i as f64))
+            }
+            Scalar::FloatingPoint(_) => Some(expected),
+            _ => None,
+        };
+        assert_eq!(tagged(repr, "float"), want, "!!float {repr:?}");
+    }
+}
+
+#[test]
+fn unknown_core_schema_suffix_is_rejected() {
+    assert_eq!(tagged("123", "unknown"), None);
+}
+
+/// A quoted scalar is a string whatever the tag says.
+#[test]
+fn quoting_wins_over_the_tag() {
+    let tag = Cow::Owned(Tag {
+        handle: "tag:yaml.org,2002:".into(),
+        suffix: "int".into(),
+    });
+    for style in [ScalarStyle::SingleQuoted, ScalarStyle::DoubleQuoted] {
+        let got = Scalar::parse_from_cow_and_metadata("12".into(), style, Some(&tag));
+        assert_eq!(got, Some(s("12")));
+    }
+}
+
+#[test]
+fn tagged_documents_resolve_like_untagged_ones() {
+    let load = |s: &str| Yaml::load_from_str(s).unwrap().pop().unwrap();
+    for (repr, expected) in [
+        ("0x1F", Yaml::Value(Scalar::Integer(31))),
+        ("0o17", Yaml::Value(Scalar::Integer(15))),
+        ("+7", Yaml::Value(Scalar::Integer(7))),
+        ("TRUE", Yaml::Value(Scalar::Boolean(true))),
+        ("False", Yaml::Value(Scalar::Boolean(false))),
+        ("NULL", Yaml::Value(Scalar::Null)),
+        ("~", Yaml::Value(Scalar::Null)),
+    ] {
+        let suffix = match expected {
+            Yaml::Value(Scalar::Integer(_)) => "int",
+            Yaml::Value(Scalar::Boolean(_)) => "bool",
+            _ => "null",
+        };
+        assert_eq!(load(repr), expected, "untagged {repr}");
+        assert_eq!(
+            load(&format!("!!{suffix} {repr}")),
+            expected,
+            "!!{suffix} {repr}"
+        );
+    }
+    assert_eq!(load("!!null"), Yaml::Value(Scalar::Null));
+}
+
+/// An empty node resolves to null, including when it carries an anchor or an alias. The parser
+/// only substitutes a `~` for the plain case, so the anchored ones reach the resolver as `""`.
+///
+/// yaml-test-suite `6KGN`.
+#[test]
+fn empty_nodes_are_null() {
+    let load = |s: &str| Yaml::load_from_str(s).unwrap().pop().unwrap();
+
+    let doc = load("---\na: &anchor\nb: *anchor\n");
+    assert!(doc["a"].is_null(), "a: {:?}", doc["a"]);
+    assert!(doc["b"].is_null(), "b: {:?}", doc["b"]);
+
+    assert!(load("&anchor\n").is_null());
+    for item in load("- &a\n- *a\n").as_sequence().unwrap() {
+        assert!(item.is_null(), "{item:?}");
+    }
+
+    // Quoting still forces a string.
+    assert_eq!(load("a: ''\n")["a"], Yaml::Value(s("")));
+}


### PR DESCRIPTION
`Scalar::parse_from_cow_and_metadata` implements the core schema a second time for the `bool`, `int` and `null` tags. The `float` arm delegates to `parse_core_schema_fp`, but the other three are still the ad-hoc parsers from 2015 and they are narrower than `parse_from_cow`, so writing the tag that asserts a scalar's type is what stops saphyr from parsing it:

```
a: 0x1F  -> Integer(31)    a: !!int 0x1F   -> BadValue
a: 0o17  -> Integer(15)    a: !!int 0o17   -> BadValue
a: TRUE  -> Boolean(true)  a: !!bool TRUE  -> BadValue
a: NULL  -> Null           a: !!null NULL  -> BadValue
a: 1.5   -> 1.5            a: !!float 1.5  -> 1.5       <- the shared arm, correct
```

This pulls `is_core_schema_null`, `parse_core_schema_bool` and `parse_core_schema_int` out next to `parse_core_schema_fp` and calls them from both paths. That closes two more divergences from the [10.3.2](https://yaml.org/spec/1.2.2/#103-core-schema) table which the duplication was hiding:

- The empty representation resolves to null. The parser substitutes a `~` for an empty node, but not when the node carries an anchor or a tag, so `a: &anchor` yielded `String("")` (yaml-test-suite `6KGN` expects `null`) and `a: !!null` yielded `BadValue`.
- `from_str_radix` accepts a sign, which `0x[0-9a-fA-F]+` and `0o[0-7]+` do not, and the `+` branch parsed the remainder as a whole integer — `0x-1F` and `++7` were read as integers.

`saphyr/tests/core_schema.rs` runs the whole 10.3.2 table and its near-misses through both paths and asserts they agree, so a future divergence reddens. Workspace suite and the yaml-test-suite runner are green; `!!bool No`, `!!int 1_000` and `!!int 0b101` still reject, and quoting still wins over the tag.
